### PR TITLE
Default HAProxy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+haproxy/*.crt
+haproxy/*.key
+haproxy/*.pem
+haproxy/haproxy.cfg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.5"
+
+services:
+  haproxy:
+    image: haproxy:2.1.2-alpine
+    container_name: haproxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./haproxy:/usr/local/etc/haproxy:ro
+    networks:
+      access-platform:
+        ipv4_address: 172.30.0.2
+networks:
+  access-platform:
+    name: access-platform
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/16

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -1,0 +1,12 @@
+# Haproxy configuration
+
+To set this up (from this directory):
+
+```
+$ cp haproxy.cfg.example haproxy.cfg
+$ ./generate_test_cert.sh
+$ cd ..
+$ docker-compose up
+```
+
+The HAProxy config should work out of the box, although feel free to meddle with it (which is why `haproxy.cfg` is in `.gitignore`). Default Docker network configs for Access platform repos will assume that HAProxy is running on your machine.

--- a/haproxy/generate_test_cert.sh
+++ b/haproxy/generate_test_cert.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+DIR=`dirname "$0"`
+
+openssl req -x509 \
+  -newkey rsa:4096 \
+  -sha256 \
+  -days 3650 \
+  -nodes \
+  -keyout $DIR/localhost.key \
+  -out $DIR/localhost.crt \
+  -subj /CN=localhost \
+  -addext subjectAltName=DNS:*.canadiana.ca
+
+cat $DIR/localhost.crt $DIR/localhost.key > $DIR/localhost.pem

--- a/haproxy/haproxy.cfg.example
+++ b/haproxy/haproxy.cfg.example
@@ -16,11 +16,18 @@ global
 
   tune.ssl.default-dh-param 4096
 
+  # debug logging
+  log stdout format raw local0 info
+
 defaults
   mode http
   timeout connect 5000ms
   timeout client 50000ms
   timeout server 50000ms
+
+  # debug logging
+  log global
+  option httplog
 
 frontend public
   bind :80
@@ -61,19 +68,19 @@ frontend public
   use_backend sapindale if is_admin
 
 backend apache
-  server local_apache 172.30.0.4:80
+  server local 172.30.0.4:80
 
 backend cap
-  server local_cap 172.30.0.3:3011
+  server local 172.30.0.3:3011
 
 backend cantaloupe
-  server local_cantaloupe 172.30.0.5:8182
+  server local 172.30.0.5:8182
 
 backend upholstery
-  server local_couch 172.30.0.6:80
+  server local 172.30.0.6:80
 
 backend amsa
-  server local_auth 172.30.0.7:80
+  server local 172.30.0.7:80
 
 backend sapindale
-  server local_admin 172.30.0.8:80
+  server local 172.30.0.8:80

--- a/haproxy/haproxy.cfg.example
+++ b/haproxy/haproxy.cfg.example
@@ -1,0 +1,79 @@
+# This is an example file for haproxy.cfg. Rename it to haproxy.cfg for it to work with docker-compose.
+# It should work out of the box, unless you have more complicated docker network settings to wrangle.
+# Run docker-compose up to set up the access-platform docker network and serve haproxy as its frontend.
+
+global
+  # Next few lines:
+  # generated 2020-02-07, Mozilla Guideline v5.4, HAProxy 2.1, OpenSSL 1.1.1d, intermediate configuration
+  # https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=intermediate&openssl=1.1.1d&guideline=5.4
+  ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets
+
+  ssl-default-server-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-server-options no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets
+
+  tune.ssl.default-dh-param 4096
+
+defaults
+  mode http
+  timeout connect 5000ms
+  timeout client 50000ms
+  timeout server 50000ms
+
+frontend public
+  bind :80
+  bind :443 ssl crt /usr/local/etc/haproxy/localhost.pem alpn h2,http/1.1
+
+  # we'll uncomment this when we're ready for HTTPS always
+  # http-response set-header Strict-Transport-Security max-age=63072000
+
+  # set X-Forwarded-(For,Host,Proto) headers
+  option forwardfor
+  http-request set-header X-Forwarded-Host %[req.hdr(Host)]
+  http-request set-header X-Forwarded-Proto https if { ssl_fc }
+  http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
+
+  # ACLs
+  acl is_unused_dom hdr_dom(host) -i online.canadiana.ca eco.canadiana.ca enligne.canadiana.ca canadianaonline.ca www.canadianaonline.ca canadianaenligne.ca www.canadianaenligne.ca whf.canadiana.ca 1812.canadiana.ca
+  acl is_gac hdr_dom(host) -i dfait-aeci.canadiana.ca
+  acl is_cdn hdr_dom(host) -i -m beg cdn.
+  acl is_org hdr_dom(host) -i -m end canadiana.org
+  acl is_static path_beg -i /cihm-error/ /schema /standards/
+  acl is_image hdr_dom(host) -i -m beg image. image-
+  acl is_image_api path_beg -i /status /configuration /tasks
+  acl is_couch hdr_dom(host) -i -m beg couch. couch-
+  acl is_auth hdr_dom(host) -i -m beg auth. auth-
+  acl is_admin hdr_dom(host) -i -m beg admin. admin-
+
+  # HTTP Request rewrites
+  http-request redirect code 301 location http://www.canadiana.ca/%[capture.req.uri] if is_unused_dom
+  http-request redirect code 301 location http://gac.canadiana.ca/%[capture.req.uri] if is_gac
+  http-request deny if is_image is_image_api
+
+  # backend selection
+  default_backend cap
+  use_backend apache if is_org || is_cdn || is_static
+  use_backend cantaloupe if is_image
+  use_backend upholstery if is_couch
+  use_backend amsa if is_auth
+  use_backend sapindale if is_admin
+
+backend apache
+  server local_apache 172.30.0.4:80
+
+backend cap
+  server local_cap 172.30.0.3:3011
+
+backend cantaloupe
+  server local_cantaloupe 172.30.0.5:8182
+
+backend upholstery
+  server local_couch 172.30.0.6:80
+
+backend amsa
+  server local_auth 172.30.0.7:80
+
+backend sapindale
+  server local_admin 172.30.0.8:80


### PR DESCRIPTION
Yes, I moved stuff around in it for no good reason.

This uses IP addresses instead of DNS, so that switching what your local DNS points to on the regular doesn't require restarting everything.

Access platform repos are going to have default configs that expect this is running.