### PR TITLE
dmdType should be optional for collection and manifest documents.

### DIFF
--- a/Databases/schemas/collection.json
+++ b/Databases/schemas/collection.json
@@ -58,5 +58,5 @@
       ]
     }
   },
-  "required": ["_id", "_rev", "label", "items", "ordered", "dmdType"]
+  "required": ["_id", "_rev", "label", "items", "ordered"]
 }

--- a/Databases/schemas/manifest.json
+++ b/Databases/schemas/manifest.json
@@ -91,5 +91,5 @@
       ]
     }
   },
-  "required": ["_id", "_rev", "label", "dmdType", "canvases"]
+  "required": ["_id", "_rev", "label", "canvases"]
 }


### PR DESCRIPTION
This is one possible resolution for #23