### PR TITLE
lapin dev `watch`: watch packages' `dist` directories and not, well, everything

### DIFF
--- a/services/lapin/package.json
+++ b/services/lapin/package.json
@@ -34,9 +34,13 @@
   "nodemonConfig": {
     "ignoreRoot": [],
     "watch": [
-      "."
+      "src",
+      "node_modules/@crkn-rcdr/access-env/dist/esm",
+      "node_modules/@crkn-rcdr/lapin-router/dist/esm",
+      "node_modules/@crkn-rcdr/lapin-router/node_modules/@crkn-rcdr/access-data/dist/esm",
+      "node_modules/@crkn-rcdr/lapin-router/node_modules/@crkn-rcdr/couch-utils/dist/esm"
     ],
-    "ext": "ts,json",
+    "ext": "ts,js,json",
     "exec": "NODE_NO_WARNINGS=1 node --loader ts-node/esm ./src/server.ts"
   }
 }


### PR DESCRIPTION
Closes #220.

Unfortunately will need to be updated every time one of lapin's repo dependencies changes its dependencies. I contemplating actually having this be set up in the root repo's package.json but that seems messier.