### PR TITLE
Unasssigning slugs, publishing objects, and searching for only manifests in the add canvas menu.

### DIFF
--- a/packages/lapin-router/src/routes/accessObject.ts
+++ b/packages/lapin-router/src/routes/accessObject.ts
@@ -39,4 +39,14 @@ export const accessObjectRouter = createRouter()
         throw httpErrorToTRPC(e);
       }
     },
+  })
+  .mutation("unassignSlug", {
+    input: NoidWithUser,
+    async resolve({ input, ctx }) {
+      try {
+        return await ctx.couch.access.unassignSlug(input);
+      } catch (e) {
+        throw httpErrorToTRPC(e);
+      }
+    },
   });

--- a/packages/lapin-router/src/routes/slug.ts
+++ b/packages/lapin-router/src/routes/slug.ts
@@ -7,6 +7,7 @@ import { createRouter } from "../router.js";
 type SlugResult = {
   id: Noid;
   slug: Slug;
+  type: "manifest" | "collection";
 };
 
 const SlugArray = z.array(Slug);

--- a/services/admin/src/lib/components/access-objects/Editor.svelte
+++ b/services/admin/src/lib/components/access-objects/Editor.svelte
@@ -116,7 +116,6 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
    * @returns void
    */
   async function setDataModel(object: AccessObject) {
-    console.log(object);
     if (!object) return;
 
     rfdc = (await import("rfdc")).default();

--- a/services/admin/src/lib/components/access-objects/EditorActions.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorActions.svelte
@@ -104,12 +104,10 @@ The editor actions component holds functionality that is responsible for perform
               user: $session.user,
               data,
             };
-            console.log("bodyObj", bodyObj);
             const response = await $session.lapin.mutation(
               `${objectModel.type}.edit`,
               bodyObj
             );
-            console.log("res", response);
             return response?.id;
           }
           return false;

--- a/services/admin/src/lib/components/access-objects/EditorActions.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorActions.svelte
@@ -166,30 +166,23 @@ The editor actions component holds functionality that is responsible for perform
         ) {
           try {
             const response = await $session.lapin.mutation(
-              `${objectModel.type}.edit`,
+              `accessObject.unassignSlug`,
               {
                 id: objectModel.id,
                 user: $session.user,
-                data: {
-                  slug: "",
-                },
               }
             );
-            console.log("res", response);
-            if (response) {
-              objectModel["slug"] = undefined;
-              object = clone(objectModel) as AccessObject; // todo: get this done with zod
-            }
+            objectModel["slug"] = undefined;
+            object = clone(objectModel) as AccessObject; // todo: get this done with zod
             return true;
           } catch (e) {
-            //error = e;
             console.log(e);
           }
         }
         return false;
       },
-      "success",
-      "fail"
+      `Placed ${objectModel["type"]} in storage. (Slug unassigned!)`,
+      `Couldn't place ${objectModel["type"]} in storage. (Slug not unassigned!)`
     );
   }
 

--- a/services/admin/src/lib/components/access-objects/Resolver.svelte
+++ b/services/admin/src/lib/components/access-objects/Resolver.svelte
@@ -87,7 +87,6 @@ The resolver component allows the user to enter a slug, and then a request is se
         if (regex.test(slug)) {
           try {
             const response = await $session.lapin.query("slug.resolve", slug);
-            console.log(slug, "Test:", response);
             if (response === null) {
               dispatch("available", { slug: initial, status: false });
               status = "ERROR";

--- a/services/admin/src/lib/components/access-objects/StatusIndicator.svelte
+++ b/services/admin/src/lib/components/access-objects/StatusIndicator.svelte
@@ -27,7 +27,9 @@ This component displays the publish status of an access object
   <span>Status:</span>
   <span
     >{object["public"]
-      ? `published on ${object["public"]}`
+      ? `published on ${new Date(
+          parseInt(`${object["public"]}`) * 1000
+        ).toLocaleString()}`
       : "unpublished"}</span
   >
 </span>

--- a/services/admin/src/lib/components/access-objects/TypeAhead.svelte
+++ b/services/admin/src/lib/components/access-objects/TypeAhead.svelte
@@ -8,6 +8,7 @@ This componenet allows the user to search the backend for any access object that
 | -- | -- | -- |
 | label : string       | optional | The label for the search input. |
 | placeholder : string | optional | The placeholder for the search input. |
+| type : string | undefined | optional | he type of object you would like to search for. |
 
 ### Usage
 ```  
@@ -31,6 +32,11 @@ This componenet allows the user to search the backend for any access object that
   export let placeholder = "Placeholder...";
 
   /**
+   * @type {string | undefined} The type of object you would like to search for.
+   */
+  export let type: string | undefined = undefined;
+
+  /**
    * @type {<EventKey extends string>(type: EventKey, detail?: any)} Triggers events that parent components can hook into.
    */
   const dispatch = createEventDispatcher();
@@ -46,9 +52,9 @@ This componenet allows the user to search the backend for any access object that
   let query = "";
 
   /**
-   * @type {string} The list of slugs that contain the search term
+   * @type {{id: string; slug: string; type: string}} The list of slugs that contain the search term
    */
-  let lookupList: string[];
+  let lookupList: { id: string; slug: string; type: string }[];
 
   /**
    * @type {string} An error message to be displayed.
@@ -64,8 +70,11 @@ This componenet allows the user to search the backend for any access object that
 
     if (query && query.length) {
       const response = await $session.lapin.query("slug.search", query);
-      if (response) {
-        lookupList = response;
+      if (response && Array.isArray(response)) {
+        lookupList = type
+          ? response.filter((res) => type === res["type"])
+          : response;
+        //console.log("lookupList", lookupList);
       } else {
         error = response.toString();
       }

--- a/services/admin/src/lib/components/canvases/CanvasViewer.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasViewer.svelte
@@ -62,17 +62,21 @@ Displays a canvas using the OpenSeadragon library
       imageURL = `https://image-tor.canadiana.ca/iiif/2/${encodeURIComponent(
         canvas["id"]
       )}/info.json`;
-      OpenSeadragon.default({
-        element: container,
-        prefixUrl: "/openseadragon/images/", // for the icons the viewer uses
-        tileSources: [imageURL],
-        viewportMargins: {
-          top: 0,
-          bottom: 0,
-        },
-        immediateRender: true,
-        ...options,
-      });
+      try {
+        OpenSeadragon.default({
+          element: container,
+          prefixUrl: "/openseadragon/images/", // for the icons the viewer uses
+          tileSources: [imageURL],
+          viewportMargins: {
+            top: 0,
+            bottom: 0,
+          },
+          immediateRender: true,
+          ...options,
+        });
+      } catch (e) {
+        console.log("OpenSeadragon error:", e);
+      }
     }
   }
 

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -41,7 +41,6 @@ TODO
   const DOWN_ARROW_CODE: number = 40;
   const dispatch = createEventDispatcher();
   const { session } = getStores<Session>();
-  console.log("Prit Collection:", collection);
   function setIndexModel() {
     indexModel = [];
     for (let i = 0; i < collection.members.length; i++) {
@@ -125,8 +124,6 @@ TODO
     }
   }
   function handleCancelPressed() {
-    console.log("selected test", activeMemberIndex);
-    console.log("selected Collection", selectedCollection);
     selectedCollection = [];
     addedMember = false;
   }

--- a/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
+++ b/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
@@ -164,6 +164,7 @@ This component allows the user to search through other manifests and select canv
         <!--Todo: ask how best to limit to only manifests-->
         <TypeAhead
           placeholder="Search for a manifest to add canvases from..."
+          type="manifest"
           on:selected={handleSelect}
           on:keypress={() => (error = "")}
         />

--- a/services/admin/src/routes/index.svelte
+++ b/services/admin/src/routes/index.svelte
@@ -13,7 +13,7 @@
    */
   function slugSelected(event: CustomEvent<string>) {
     const noid = event.detail;
-    goto(`/object/${noid}`);
+    if (noid) goto(`/object/${noid}`);
   }
 </script>
 


### PR DESCRIPTION
Fixes the front end /admin app in response to: https://github.com/crkn-rcdr/Access-Platform/pull/215
- Slugs can be unassigned (object placed in storage)
- Objects can be published/unpublished
- Add canvas menu only brings up manifests in the search.