### PR TITLE
Replace isequal from fast-deep-equals with lodash's single module for .isequal for canvas comparison

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
       '@types/jsonwebtoken': ^8.5.4
       cookie: ^0.4.1
       deep-object-diff: ^1.1.0
-      fast-deep-equal: ^3.1.3
       jsonwebtoken: ^8.5.1
+      lodash.isequal: ^4.5.0
       npm-run-all: ^4.1.5
       openseadragon: ^2.4.2
       rfdc: ^1.3.0
@@ -133,15 +133,15 @@ importers:
       '@trpc/client': 8.4.2
       cookie: 0.4.1
       deep-object-diff: 1.1.0
-      fast-deep-equal: 3.1.3
       jsonwebtoken: 8.5.1
+      lodash.isequal: 4.5.0
       openseadragon: 2.4.2
       rfdc: 1.3.0
       svelte-icons: 2.1.0
     devDependencies:
       '@crkn-rcdr/lapin-router': link:../../packages/lapin-router
       '@sveltejs/adapter-node': 1.0.0-next.39
-      '@sveltejs/kit': 1.0.0-next.144_svelte@3.40.1
+      '@sveltejs/kit': 1.0.0-next.146_svelte@3.40.1
       '@types/cookie': 0.4.1
       '@types/jsonwebtoken': 8.5.4
       npm-run-all: 4.1.5
@@ -295,8 +295,8 @@ packages:
       tiny-glob: 0.2.9
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.144_svelte@3.40.1:
-    resolution: {integrity: sha512-c+UX7Xp3PUzkGvXgkXAJpM8+zbouTMukhWIIqehUUFMXJlRlbRiO1YkiZRWFqbb7aV80d8klCWGprFXQVcwlbw==}
+  /@sveltejs/kit/1.0.0-next.146_svelte@3.40.1:
+    resolution: {integrity: sha512-MSatcaCRfjl88Prd5mW4pNOJ3Gsr525+Vjr24MoKtyTt6PZQmTfQsDVwyP93exn/6w2xl9uMCW6cFpDVBu7jSg==}
     engines: {node: ^12.20 || >=14.13}
     hasBin: true
     peerDependencies:
@@ -891,8 +891,8 @@ packages:
       color-string: 1.6.0
     dev: true
 
-  /colorette/1.2.2:
-    resolution: {integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==}
+  /colorette/1.3.0:
+    resolution: {integrity: sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==}
     dev: true
 
   /colors/1.4.0:
@@ -1233,10 +1233,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /fast-deep-equal/3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: false
 
   /fast-diff/1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
@@ -1960,6 +1956,10 @@ packages:
     resolution: {integrity: sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=}
     dev: false
 
+  /lodash.isequal/4.5.0:
+    resolution: {integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=}
+    dev: false
+
   /lodash.isinteger/4.0.4:
     resolution: {integrity: sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=}
     dev: false
@@ -2495,7 +2495,7 @@ packages:
     resolution: {integrity: sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      colorette: 1.2.2
+      colorette: 1.3.0
       nanoid: 3.1.23
       source-map-js: 0.6.2
     dev: true
@@ -2694,8 +2694,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /rollup/2.56.1:
-    resolution: {integrity: sha512-KkrsNjeiTfGJMUFBi/PNfj3fnt70akqdoNXOjlzwo98uA1qrlkmgt6SGaK5OwhyDYCVnJb6jb2Xa2wbI47P4Nw==}
+  /rollup/2.56.2:
+    resolution: {integrity: sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -3310,7 +3310,7 @@ packages:
       esbuild: 0.12.19
       postcss: 8.3.6
       resolve: 1.20.0
-      rollup: 2.56.1
+      rollup: 2.56.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
       cookie: ^0.4.1
       deep-object-diff: ^1.1.0
       jsonwebtoken: ^8.5.1
-      lodash.isequal: ^4.5.0
+      lodash-es: ^4.17.21
       npm-run-all: ^4.1.5
       openseadragon: ^2.4.2
       rfdc: ^1.3.0
@@ -134,7 +134,7 @@ importers:
       cookie: 0.4.1
       deep-object-diff: 1.1.0
       jsonwebtoken: 8.5.1
-      lodash.isequal: 4.5.0
+      lodash-es: 4.17.21
       openseadragon: 2.4.2
       rfdc: 1.3.0
       svelte-icons: 2.1.0
@@ -1948,16 +1948,16 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash-es/4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.includes/4.3.0:
     resolution: {integrity: sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=}
     dev: false
 
   /lodash.isboolean/3.0.3:
     resolution: {integrity: sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=}
-    dev: false
-
-  /lodash.isequal/4.5.0:
-    resolution: {integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=}
     dev: false
 
   /lodash.isinteger/4.0.4:

--- a/services/admin/package.json
+++ b/services/admin/package.json
@@ -22,8 +22,8 @@
     "@trpc/client": "^8.4.2",
     "cookie": "^0.4.1",
     "deep-object-diff": "^1.1.0",
-    "fast-deep-equal": "^3.1.3",
     "jsonwebtoken": "^8.5.1",
+    "lodash.isequal": "^4.5.0",
     "openseadragon": "^2.4.2",
     "rfdc": "^1.3.0",
     "svelte-icons": "^2.1.0"

--- a/services/admin/package.json
+++ b/services/admin/package.json
@@ -23,7 +23,7 @@
     "cookie": "^0.4.1",
     "deep-object-diff": "^1.1.0",
     "jsonwebtoken": "^8.5.1",
-    "lodash.isequal": "^4.5.0",
+    "lodash-es": "^4.17.21",
     "openseadragon": "^2.4.2",
     "rfdc": "^1.3.0",
     "svelte-icons": "^2.1.0"

--- a/services/admin/src/lib/validation.ts
+++ b/services/admin/src/lib/validation.ts
@@ -12,7 +12,7 @@ import {
   TextRecord,
   ObjectList,
 } from "@crkn-rcdr/access-data";
-import equal from "fast-deep-equal";
+import * as isequal from "lodash.isequal";
 
 /**
  * Checks to see if the parameter bassed in is a valid collection
@@ -63,7 +63,7 @@ function checkChangeIsValid(objectModel: AccessObject) {
  * @returns boolean
  */
 function checkModelChanged(object: AccessObject, objectModel: AccessObject) {
-  return !equal(object, objectModel);
+  return !isequal(object, objectModel);
 }
 
 /**

--- a/services/admin/src/lib/validation.ts
+++ b/services/admin/src/lib/validation.ts
@@ -12,7 +12,7 @@ import {
   TextRecord,
   ObjectList,
 } from "@crkn-rcdr/access-data";
-import * as isequal from "lodash.isequal";
+import isEqual from "lodash-es/isEqual";
 
 /**
  * Checks to see if the parameter bassed in is a valid collection
@@ -63,7 +63,7 @@ function checkChangeIsValid(objectModel: AccessObject) {
  * @returns boolean
  */
 function checkModelChanged(object: AccessObject, objectModel: AccessObject) {
-  return !isequal(object, objectModel);
+  return !isEqual(object, objectModel);
 }
 
 /**


### PR DESCRIPTION
I noticed with the other method that when I added the same canvases from: https://access-dev.canadiana.ca/object/69429/m02n4zg6h671 to itself (selected the first couple canvases) that the isequal from fast deep equals returned true, which is wrong. So I switched to using:

https://www.npmjs.com/package/lodash.isequal

I saw somewhere on github that we will make our own implementation, I'll switch to that once it's done.