### PR TITLE
Sidenav increase contrast between active and inactive tabs

### DIFF
--- a/services/admin/src/lib/components/access-objects/Editor.svelte
+++ b/services/admin/src/lib/components/access-objects/Editor.svelte
@@ -67,7 +67,7 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
           },
         },
         {
-          name: "Content",
+          name: "Manage Content",
           componentData: {
             contentComponent: ManifestContentEditor,
             contentComponentProps: { manifest: objectModel },
@@ -94,7 +94,7 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
           },
         },
         {
-          name: "Members",
+          name: "Manage Members",
           componentData: {
             contentComponent: CollectionContentEditor,
             contentComponentProps: { collection: objectModel },

--- a/services/admin/src/lib/components/shared/SideMenuPageListButton.svelte
+++ b/services/admin/src/lib/components/shared/SideMenuPageListButton.svelte
@@ -25,12 +25,14 @@ None
 
 <style>
   li {
-    background: rgba(0, 0, 0, 0.06);
     padding: var(--perfect-fourth-7) var(--perfect-fourth-4);
-    cursor: pointer;
     font-weight: 500;
   }
+  li:hover {
+    background: rgba(255, 255, 255, 0.45);
+    transition: background 0.5s ease;
+  }
   :global(.side-menu-page-list-button.active) {
-    background: rgba(0, 0, 0, 0.02);
+    color: var(--primary);
   }
 </style>

--- a/services/admin/src/lib/components/shared/SideMenuPageListButton.svelte
+++ b/services/admin/src/lib/components/shared/SideMenuPageListButton.svelte
@@ -28,11 +28,12 @@ None
     padding: var(--perfect-fourth-7) var(--perfect-fourth-4);
     font-weight: 500;
   }
-  li:hover {
+  li:not(.active):hover {
     background: rgba(255, 255, 255, 0.45);
     transition: background 0.5s ease;
   }
   :global(.side-menu-page-list-button.active) {
+    background: rgba(255, 255, 255, 0.45);
     color: var(--primary);
   }
 </style>

--- a/services/admin/static/style.css
+++ b/services/admin/static/style.css
@@ -20,6 +20,7 @@
     var(--green) -106.9%,
     var(--teal) 93.69%
   );
+  --color-gradient-text: linear-gradient(45deg, var(--green), var(--teal));
   --light-font: white;
   --dark-font: black;
 


### PR DESCRIPTION
Maybe font colour can be used to indicate the active page? Any time I set the background to something too contrasting to the rest of the page my eyes go directly to the side nav instead of the editor fields.

On hover we can do some more fancy stuff, like lightening the background a fair bit.

