### PR TITLE
Dmd Task: Step 4 Interface

### DIFF
--- a/packages/data/src/dmd/Task.ts
+++ b/packages/data/src/dmd/Task.ts
@@ -35,6 +35,16 @@ const ParseRecord = z
      * Any message returned by the metadata processor.
      */
     message: z.string().optional(),
+
+    /**
+     * If the item was found on an access platform.
+     */
+    access: z.boolean().optional(),
+
+    /**
+     * If the item was found on preservation.
+     */
+    preservation: z.boolean().optional(),
   })
   .refine(
     (record) => !record.parsed || (record.id && record.label),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
       svelte-icons: 2.1.0
     devDependencies:
       '@crkn-rcdr/lapin-router': link:../../packages/lapin-router
-      '@sveltejs/adapter-node': 1.0.0-next.39
-      '@sveltejs/kit': 1.0.0-next.146_svelte@3.40.1
+      '@sveltejs/adapter-node': 1.0.0-next.40
+      '@sveltejs/kit': 1.0.0-next.147_svelte@3.40.1
       '@types/cookie': 0.4.1
       '@types/jsonwebtoken': 8.5.4
       npm-run-all: 4.1.5
@@ -288,21 +288,21 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /@sveltejs/adapter-node/1.0.0-next.39:
-    resolution: {integrity: sha512-5esWwnomzO3Oq6Ie5HQ64lpTTESvlPfN/MS9DtyjkVEna2pgNp2/Pi+6eIunAYyPzkvaq2Ac6ngqQJ3QU1ESEA==}
+  /@sveltejs/adapter-node/1.0.0-next.40:
+    resolution: {integrity: sha512-1FPqp7+PBLhlA29ND25lsOrxOlWKbeeRMNjR3WFPFUwi6147eZ4/TYOk0rgVZ3MzT9iqf5BYKuHwaI/BpgO0Yg==}
     dependencies:
-      esbuild: 0.12.19
+      esbuild: 0.12.20
       tiny-glob: 0.2.9
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.146_svelte@3.40.1:
-    resolution: {integrity: sha512-MSatcaCRfjl88Prd5mW4pNOJ3Gsr525+Vjr24MoKtyTt6PZQmTfQsDVwyP93exn/6w2xl9uMCW6cFpDVBu7jSg==}
+  /@sveltejs/kit/1.0.0-next.147_svelte@3.40.1:
+    resolution: {integrity: sha512-rAABsKlC1K/B4VfqT2SaVO29t+OV8deseSJ9l+hV7j9zkswTwiJ7h37tZ5SfnvMgCHemcNjXg8Gzg+0U1MCfEA==}
     engines: {node: ^12.20 || >=14.13}
     hasBin: true
     peerDependencies:
       svelte: ^3.34.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.15_svelte@3.40.1+vite@2.4.4
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.17_svelte@3.40.1+vite@2.4.4
       cheap-watch: 1.0.3
       sade: 1.7.4
       svelte: 3.40.1
@@ -312,8 +312,8 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.15_svelte@3.40.1+vite@2.4.4:
-    resolution: {integrity: sha512-8yGX7PxaqtvWw+GHiO2DV7lZ4M7DwIrFq+PgZGZ9X09PuoSeaWszm76GWQXJMKHoPPhdA9084662en9qbv4aRw==}
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.17_svelte@3.40.1+vite@2.4.4:
+    resolution: {integrity: sha512-Xh/YYqBMDJnDheutnGHk/I5TO6w9gZ2GMgvG+qQm/gpIRkaTLts6Mw5xDe6cac/nH/aVPPVPibhq2pf26d44fA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5
@@ -1188,8 +1188,8 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /esbuild/0.12.19:
-    resolution: {integrity: sha512-5NuT1G6THW7l3fsSCDkcPepn24R0XtyPjKoqKHD8LfhqMXzCdz0mrS9HgO6hIhzVT7zt0T+JGbzCqF5AH8hS9w==}
+  /esbuild/0.12.20:
+    resolution: {integrity: sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==}
     hasBin: true
     requiresBuild: true
     dev: true
@@ -2153,8 +2153,8 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /nanoid/3.1.23:
-    resolution: {integrity: sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==}
+  /nanoid/3.1.25:
+    resolution: {integrity: sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -2496,7 +2496,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       colorette: 1.3.0
-      nanoid: 3.1.23
+      nanoid: 3.1.25
       source-map-js: 0.6.2
     dev: true
 
@@ -3307,7 +3307,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      esbuild: 0.12.19
+      esbuild: 0.12.20
       postcss: 8.3.6
       resolve: 1.20.0
       rollup: 2.56.2

--- a/services/admin/src/lib/components/access-objects/TypeAhead.svelte
+++ b/services/admin/src/lib/components/access-objects/TypeAhead.svelte
@@ -105,13 +105,7 @@ This componenet allows the user to search the backend for any access object that
   />
 
   {#if query && lookupList}
-    <br />
     <table>
-      <thead>
-        <tr>
-          <th>Search Results</th>
-        </tr>
-      </thead>
       <tbody>
         {#each lookupList as item}
           <tr class="clickable" on:click={() => selectItem(item)}>

--- a/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
@@ -66,3 +66,9 @@
     <JsonTree value={{ object: JSON.parse(previewItem["message"]) }} />
   </div>
 </Modal>
+
+<style>
+  thead {
+    background: var(--backdrop-bg);
+  }
+</style>

--- a/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { SucceededDMDTask } from "@crkn-rcdr/access-data";
+  import JsonTree from "$lib/components/shared/JsonTree.svelte";
+  import Modal from "$lib/components/shared/Modal.svelte";
+  export let dmdTask:
+    | WaitingDMDTask
+    | FailedDMDTask
+    | SucceededDMDTask
+    | undefined;
+
+  let showJSONPreview = false;
+  let previewItem;
+</script>
+
+{#if dmdTask?.["items"]?.length}
+  <table>
+    <thead>
+      <tr>
+        <th>Id</th>
+        <th>Label</th>
+        <th>Value</th>
+        {#if "access" in dmdTask["items"][0]}
+          <th>Access</th>
+        {/if}
+        {#if "preservation" in dmdTask["items"][0]}
+          <th>Preservation</th>
+        {/if}
+      </tr>
+    </thead>
+    <tbody>
+      {#each dmdTask["items"] as item}
+        {#if typeof item === "object"}
+          <tr>
+            <td>{item["id"]}</td>
+            <td>{item["label"]}</td>
+            <td>
+              {#if item["parsed"]}
+                <button
+                  class="button secondary sm"
+                  on:click={() => {
+                    previewItem = item;
+                    showJSONPreview = true;
+                  }}>Preview</button
+                >
+              {:else}
+                {item["message"]}
+              {/if}
+            </td>
+            {#if "access" in item}
+              <td>{item["access"]}</td>
+            {/if}
+            {#if "preservation" in item}
+              <td>{item["preservation"]}</td>
+            {/if}
+          </tr>
+        {/if}
+      {/each}
+    </tbody>
+  </table>
+{:else}
+  No items.
+{/if}
+
+<Modal bind:open={showJSONPreview} title={`Preview JSON`} size="lg">
+  <div slot="body" class="code-block">
+    <JsonTree value={{ object: JSON.parse(previewItem["message"]) }} />
+  </div>
+</Modal>

--- a/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
@@ -20,10 +20,10 @@
         <th>Label</th>
         <th>Value</th>
         {#if "access" in dmdTask["items"][0]}
-          <th>Access</th>
+          <th>Found in Access</th>
         {/if}
         {#if "preservation" in dmdTask["items"][0]}
-          <th>Preservation</th>
+          <th>Found in Preservation</th>
         {/if}
       </tr>
     </thead>

--- a/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdItemsTable.svelte
@@ -66,9 +66,3 @@
     <JsonTree value={{ object: JSON.parse(previewItem["message"]) }} />
   </div>
 </Modal>
-
-<style>
-  thead {
-    background: var(--backdrop-bg);
-  }
-</style>

--- a/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
@@ -1,44 +1,9 @@
-<!--
-@component
-### Overview
-Displays a dmd task in an error state.
-
-### Properties
-|    |    |    |
-| -- | -- | -- |
-| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
-| message: string | required | The message to be displayed in the error notification bar. |
-
-### Usage
-```  
-<DmdSplitFailureViewer
-  {dmdTask}
-  message="Something went wrong!"
-/>
-```
--->
-<script lang="ts">
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
+<script>
   import DmdTaskTimeInfoTable from "$lib/components/dmd/DmdTaskTimeInfoTable.svelte";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
 
-  /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
-   */
-  export let dmdTask:
-    | WaitingDMDTask
-    | FailedDMDTask
-    | SucceededDMDTask
-    | undefined;
-
-  /**
-   * @type {string} The message to be displayed in the error notification bar.
-   */
-  export let message: string | undefined;
+  export let dmdTask;
+  export let message;
 </script>
 
 <div class="hero hero__gradient full-page failure">
@@ -46,7 +11,7 @@ Displays a dmd task in an error state.
     <div
       class="auto-align auto-align__block auto-align__column auto-align__a-center"
     >
-      <h6>Metadata Upload Failed!</h6>
+      <h6>DMD Task Failed!</h6>
       <NotificationBar {message} status="fail" />
       <DmdTaskTimeInfoTable {dmdTask} />
       <a href="/dmd/new" class="dmd-task-try-again">

--- a/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
@@ -1,9 +1,44 @@
-<script>
+<!--
+@component
+### Overview
+Displays a dmd task in an error state.
+
+### Properties
+|    |    |    |
+| -- | -- | -- |
+| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
+| message: string | required | The message to be displayed in the error notification bar. |
+
+### Usage
+```  
+<DmdSplitFailureViewer
+  {dmdTask}
+  message="Something went wrong!"
+/>
+```
+-->
+<script lang="ts">
+  import type {
+    WaitingDMDTask,
+    FailedDMDTask,
+    SucceededDMDTask,
+  } from "@crkn-rcdr/access-data";
   import DmdTaskTimeInfoTable from "$lib/components/dmd/DmdTaskTimeInfoTable.svelte";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
 
-  export let dmdTask;
-  export let message;
+  /**
+   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
+   */
+  export let dmdTask:
+    | WaitingDMDTask
+    | FailedDMDTask
+    | SucceededDMDTask
+    | undefined;
+
+  /**
+   * @type {string} The message to be displayed in the error notification bar.
+   */
+  export let message: string | undefined;
 </script>
 
 <div class="hero hero__gradient full-page failure">

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -5,8 +5,11 @@
   import NotificationBar from "../shared/NotificationBar.svelte";
   import TempPrefixSelector from "./TempPrefixSelector.svelte";
 
-  let activeStepIndex = 0;
+  let prefix;
+  let shouldUpdateInAccess = true;
+  let shouldUpdateInPreservation = true;
 
+  let activeStepIndex = 0;
   let hasLookupRan = false;
   let showLoader = false;
 </script>
@@ -22,20 +25,22 @@
     >
       <div slot="icon">1</div>
       <div class="depositor-grid grid grid__col_2">
-        <TempPrefixSelector />
-        <button
-          class="primary"
-          on:click={() => {
-            showLoader = true;
-            setTimeout(() => {
-              activeStepIndex = 1;
-              hasLookupRan = true;
-              showLoader = false;
-            }, 2000);
-          }}
-        >
-          Look-up
-        </button>
+        <TempPrefixSelector bind:prefix />
+        {#if prefix?.length}
+          <button
+            class="primary"
+            on:click={() => {
+              showLoader = true;
+              setTimeout(() => {
+                activeStepIndex = 1;
+                hasLookupRan = true;
+                showLoader = false;
+              }, 2000);
+            }}
+          >
+            Look-up
+          </button>
+        {/if}
       </div>
       <br />
       <br />
@@ -107,13 +112,23 @@
         <div class="update-grid grid grid__col_3">
           <span>
             <label for="access">Update in access</label>
-            <input name="access" type="checkbox" checked />
+            <input
+              name="access"
+              type="checkbox"
+              bind:checked={shouldUpdateInAccess}
+            />
           </span>
           <span>
             <label for="preservation">Update in preservation</label>
-            <input name="preservation" type="checkbox" checked />
+            <input
+              name="preservation"
+              type="checkbox"
+              bind:checked={shouldUpdateInPreservation}
+            />
           </span>
-          <button class="primary">Update Descriptive Metadata Records</button>
+          {#if shouldUpdateInAccess || shouldUpdateInPreservation}
+            <button class="primary">Update Descriptive Metadata Records</button>
+          {/if}
         </div>
         <br />
         <table>
@@ -122,8 +137,8 @@
               <th>Id</th>
               <th>Label</th>
               <th>Value</th>
-              <th>In Access?</th>
-              <th>In Preservation?</th>
+              <th>Access</th>
+              <th>Preservation</th>
             </tr>
           </thead>
           <tbody>

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -1,17 +1,102 @@
 <script lang="ts">
+  import type {
+    FailedDMDTask,
+    SucceededDMDTask,
+    WaitingDMDTask,
+  } from "@crkn-rcdr/access-data";
   import ScrollStepper from "$lib/components/shared/ScrollStepper.svelte";
   import ScrollStepperStep from "$lib/components/shared/ScrollStepperStep.svelte";
-  import Loading from "../shared/Loading.svelte";
-  import NotificationBar from "../shared/NotificationBar.svelte";
-  import TempPrefixSelector from "./TempPrefixSelector.svelte";
+  import Loading from "$lib/components/shared/Loading.svelte";
+  import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
+  import DmdItemsTable from "$lib/components/dmd/DmdItemsTable.svelte";
+  import TempPrefixSelector from "$lib/components/dmd/TempPrefixSelector.svelte";
 
-  let prefix;
+  let prefix = "oocihm";
   let shouldUpdateInAccess = true;
   let shouldUpdateInPreservation = true;
 
   let activeStepIndex = 0;
   let hasLookupRan = false;
   let showLoader = false;
+
+  export let dmdTask:
+    | WaitingDMDTask
+    | FailedDMDTask
+    | SucceededDMDTask
+    | undefined = {
+    id: "123",
+    updated: "1628785112",
+    attachments: {
+      // ...metadata file info
+    },
+    user: {
+      email: "email",
+      name: "name",
+    }, //for now
+    mdType: "marcooe",
+    process: {
+      requestDate: "1628785101",
+      succeeded: true,
+      message: "The process.message from the backend",
+    },
+    items: [
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+    ],
+  };
 </script>
 
 <div class="wrapper">
@@ -31,6 +116,11 @@
             class="primary"
             on:click={() => {
               showLoader = true;
+              for (const item of dmdTask["items"]) {
+                item["access"] = true;
+                item["preservation"] = true;
+              }
+              dmdTask = dmdTask;
               setTimeout(() => {
                 activeStepIndex = 1;
                 hasLookupRan = true;
@@ -49,57 +139,7 @@
           <Loading backgroundType="secondary" />
         </div>
       {:else if !hasLookupRan}
-        <table>
-          <thead>
-            <tr>
-              <th>Id</th>
-              <th>Label</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-          </tbody>
-        </table>
+        <DmdItemsTable bind:dmdTask />
       {/if}
     </ScrollStepperStep>
     <ScrollStepperStep
@@ -131,75 +171,7 @@
           {/if}
         </div>
         <br />
-        <table>
-          <thead>
-            <tr>
-              <th>Id</th>
-              <th>Label</th>
-              <th>Value</th>
-              <th>Access</th>
-              <th>Preservation</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-            <tr>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-              <td>value</td>
-            </tr>
-          </tbody>
-        </table>
+        <DmdItemsTable bind:dmdTask />
       </div>
     </ScrollStepperStep>
   </ScrollStepper>

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -870,19 +870,38 @@
   };
 </script>
 
+<!--OPTION B-->
 <div class="wrapper">
-  <!--OPTION B-->
-  <ScrollStepper bind:activeStepIndex displayPrevious={true}>
-    <ScrollStepperStep
-      title={`Look up items in their access platform${
-        hasLookupRan ? " again:" : ":"
-      }`}
-    >
-      <div slot="icon">1</div>
-      <div class="depositor-grid grid grid__col_2">
-        <TempPrefixSelector bind:prefix />
-        {#if prefix?.length}
-          <!--button
+  <br />
+  <NotificationBar message="Metadata uploaded successfully!" />
+  <br />
+
+  <div class="auto-align">
+    <div class="metadata-table ">
+      <DmdItemsTable bind:dmdTask />
+    </div>
+    <div class="metadata-form">
+      <ScrollStepper
+        bind:activeStepIndex
+        displayPrevious={true}
+        enableAutoScrolling={false}
+      >
+        <ScrollStepperStep
+          title={`Look-up items in an access platform${
+            hasLookupRan ? " again" : ""
+          }`}
+        >
+          <div slot="icon">1</div>
+
+          <br />
+          <!--div class="depositor-grid grid grid__col_2"-->
+          <TempPrefixSelector bind:prefix />
+          <br />
+
+          <br />
+
+          {#if prefix?.length}
+            <!--button
             class="primary"
             on:click={() => {
               showLoader = true;
@@ -900,92 +919,93 @@
           >
             Look-up
           </button-->
-          <button
-            class="primary"
-            on:click={() => {
-              for (const item of dmdTask["items"]) {
-                delete item["access"];
-                delete item["preservation"];
-              }
-              dmdTask = dmdTask;
-              showLoader = true;
-              setTimeout(() => {
-                activeStepIndex = 1;
+            <button
+              class="primary"
+              class:secondary={hasLookupRan}
+              on:click={() => {
                 for (const item of dmdTask["items"]) {
-                  item["access"] = true;
-                  item["preservation"] = true;
+                  delete item["access"];
+                  delete item["preservation"];
                 }
                 dmdTask = dmdTask;
-                hasLookupRan = true;
-                showLoader = false;
-                showLookup = false;
-              }, 12000);
-            }}
-          >
-            <span
-              class="auto-align auto-align__a-center"
-              class:loading-button={showLoader}
+                showLoader = true;
+                setTimeout(() => {
+                  activeStepIndex = 1;
+                  for (const item of dmdTask["items"]) {
+                    item["access"] = true;
+                    item["preservation"] = true;
+                  }
+                  dmdTask = dmdTask;
+                  hasLookupRan = true;
+                  showLoader = false;
+                  showLookup = false;
+                }, 12000);
+              }}
             >
-              {#if showLoader}
-                <Loading size="sm" />
-              {/if}
-              <span class="text"
-                >{!showLoader
-                  ? hasLookupRan
-                    ? "Look-up Again"
-                    : "Look-up"
-                  : "Looking-up..."}</span
+              <span
+                class="auto-align auto-align__a-center"
+                class:loading-button={showLoader}
               >
-            </span>
-          </button>
-        {/if}
-      </div>
-      <!--{#if showLoader}
+                {#if showLoader}
+                  <Loading size="sm" />
+                {/if}
+                <span class="text"
+                  >{!showLoader
+                    ? hasLookupRan
+                      ? "Look-up Again"
+                      : "Look-up"
+                    : "Looking-up..."}</span
+                >
+              </span>
+            </button>
+          {/if}
+          <!--/div-->
+          <!--{#if showLoader}
         <br />
         <br />
         <div class="loading-wrap">
           <Loading backgroundType="secondary" />
         </div-->
-      {#if !hasLookupRan}
-        <DmdItemsTable bind:dmdTask />
-      {/if}
-    </ScrollStepperStep>
-    <ScrollStepperStep
-      title="Update the descriptive metadata records of the items:"
-      isLastStep={true}
-    >
-      <div slot="icon">2</div>
-      {#if !showLoader}
-        <div class="update-wrap">
-          <div class="update-grid grid grid__col_3">
-            <span>
-              <label for="access">Update in access</label>
-              <input
-                name="access"
-                type="checkbox"
-                bind:checked={shouldUpdateInAccess}
-              />
-            </span>
-            <span>
-              <label for="preservation">Update in preservation</label>
-              <input
-                name="preservation"
-                type="checkbox"
-                bind:checked={shouldUpdateInPreservation}
-              />
-            </span>
-            {#if shouldUpdateInAccess || shouldUpdateInPreservation}
-              <button class="primary"
-                >Update Descriptive Metadata Records</button
-              >
-            {/if}
-          </div>
-          <br />
-          <DmdItemsTable bind:dmdTask />
-        </div>
-      {/if}
-    </ScrollStepperStep>
-  </ScrollStepper>
+        </ScrollStepperStep>
+        <ScrollStepperStep
+          title="Update the descriptive metadata records of the items"
+          isLastStep={true}
+        >
+          <div slot="icon">2</div>
+          {#if !showLoader}
+            <br />
+            <div class="update-wrap">
+              <!--div class="update-grid grid grid__col_3"-->
+              <div>
+                <label for="access">Update in access</label>
+                <input
+                  name="access"
+                  type="checkbox"
+                  bind:checked={shouldUpdateInAccess}
+                />
+              </div>
+              <br />
+              <div>
+                <label for="preservation">Update in preservation</label>
+                <input
+                  name="preservation"
+                  type="checkbox"
+                  bind:checked={shouldUpdateInPreservation}
+                />
+              </div>
+              <br />
+              {#if shouldUpdateInAccess || shouldUpdateInPreservation}
+                <button class="primary"
+                  >Update Descriptive Metadata Records</button
+                >
+              {/if}
+              <!--/div-->
+            </div>
+          {/if}
+        </ScrollStepperStep>
+      </ScrollStepper>
+    </div>
+  </div>
 </div>
 
 <!--
@@ -993,7 +1013,7 @@
   pass actual access name to table
   cleanup
   document
-  <NotificationBar message=""/>"
+  "
 -->
 
 <!--div class="hero hero__gradient">
@@ -1086,6 +1106,13 @@
   .hero h3 {
     padding: var(--perfect-fourth-2) 0 var(--perfect-fourth-4) 0 !important;
   }
+  .metadata-form {
+    flex: 1;
+    padding-left: 4rem;
+  }
+  .metadata-table {
+    flex: 1.5;
+  }
   /*.tab {
     min-width: 20rem;
     padding: var(--perfect-fourth-7) 0;
@@ -1103,9 +1130,6 @@
   .loading-wrap {
     margin-top: var(--perfect-fourth-8);
     margin-bottom: var(--perfect-fourth-8);
-  }
-  .update-wrap {
-    min-height: 70rem;
   }
   .loading-button .text {
     margin-left: var(--margin-sm);

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -99,82 +99,84 @@
   };
 </script>
 
+<!--
+  Todo: hide access selector if has run = until user click edit icon on found in access
+  pass actual access name to table
+  cleanup
+  document
+-->
 <div class="wrapper">
-  <br />
   <NotificationBar message="Metadata uploaded sucessfully!" />
-  <ScrollStepper bind:activeStepIndex displayPrevious={true}>
-    <ScrollStepperStep
-      title={`${
-        hasLookupRan ? "Re-select" : "Select"
-      } the Access Platform of the Items`}
-    >
-      <div slot="icon">1</div>
-      <div class="depositor-grid grid grid__col_2">
-        <TempPrefixSelector bind:prefix />
-        {#if prefix?.length}
-          <button
-            class="primary"
-            on:click={() => {
-              showLoader = true;
-              for (const item of dmdTask["items"]) {
-                item["access"] = true;
-                item["preservation"] = true;
-              }
-              dmdTask = dmdTask;
-              setTimeout(() => {
-                activeStepIndex = 1;
-                hasLookupRan = true;
-                showLoader = false;
-              }, 2000);
-            }}
+
+  <div class="depositor-grid grid grid__col_2">
+    <TempPrefixSelector bind:prefix />
+    {#if prefix?.length}
+      <button
+        class="primary"
+        on:click={() => {
+          for (const item of dmdTask["items"]) {
+            delete item["access"];
+            delete item["preservation"];
+          }
+          dmdTask = dmdTask;
+          showLoader = true;
+          setTimeout(() => {
+            for (const item of dmdTask["items"]) {
+              item["access"] = true;
+              item["preservation"] = true;
+            }
+            dmdTask = dmdTask;
+            hasLookupRan = true;
+            showLoader = false;
+          }, 12000);
+        }}
+      >
+        <span
+          class="auto-align  auto-align__a-center"
+          class:loading-button={showLoader}
+        >
+          {#if showLoader}
+            <Loading size="sm" />
+          {/if}
+          <span class="text"
+            >{!showLoader
+              ? hasLookupRan
+                ? "Look-up Again"
+                : "Look-up"
+              : "Looking-up..."}</span
           >
-            Look-up
-          </button>
+        </span>
+      </button>
+    {/if}
+  </div>
+
+  {#if hasLookupRan}
+    <div>
+      <div class="update-grid grid grid__col_3">
+        <span>
+          <label for="access">Update in access</label>
+          <input
+            name="access"
+            type="checkbox"
+            bind:checked={shouldUpdateInAccess}
+          />
+        </span>
+        <span>
+          <label for="preservation">Update in preservation</label>
+          <input
+            name="preservation"
+            type="checkbox"
+            bind:checked={shouldUpdateInPreservation}
+          />
+        </span>
+        {#if shouldUpdateInAccess || shouldUpdateInPreservation}
+          <button class="primary">Update Descriptive Metadata Records</button>
         {/if}
       </div>
       <br />
-      <br />
-      {#if showLoader}
-        <div class="loading-wrap">
-          <Loading backgroundType="secondary" />
-        </div>
-      {:else if !hasLookupRan}
-        <DmdItemsTable bind:dmdTask />
-      {/if}
-    </ScrollStepperStep>
-    <ScrollStepperStep
-      title="Update the Descriptive Metadata Records of the Items"
-      isLastStep={true}
-    >
-      <div slot="icon">2</div>
-
-      <div class="update-wrap">
-        <div class="update-grid grid grid__col_3">
-          <span>
-            <label for="access">Update in access</label>
-            <input
-              name="access"
-              type="checkbox"
-              bind:checked={shouldUpdateInAccess}
-            />
-          </span>
-          <span>
-            <label for="preservation">Update in preservation</label>
-            <input
-              name="preservation"
-              type="checkbox"
-              bind:checked={shouldUpdateInPreservation}
-            />
-          </span>
-          {#if shouldUpdateInAccess || shouldUpdateInPreservation}
-            <button class="primary">Update Descriptive Metadata Records</button>
-          {/if}
-        </div>
-        <br />
-        <DmdItemsTable bind:dmdTask />
-      </div>
-    </ScrollStepperStep>
-  </ScrollStepper>
+    </div>
+  {/if}
+  <DmdItemsTable bind:dmdTask />
 </div>
 
 <style>
@@ -189,5 +191,8 @@
   }
   .update-wrap {
     min-height: 70rem;
+  }
+  .loading-button .text {
+    margin-left: var(--margin-sm);
   }
 </style>

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -1,1 +1,206 @@
-Success page
+<script lang="ts">
+  import ScrollStepper from "$lib/components/shared/ScrollStepper.svelte";
+  import ScrollStepperStep from "$lib/components/shared/ScrollStepperStep.svelte";
+  import Loading from "../shared/Loading.svelte";
+  import NotificationBar from "../shared/NotificationBar.svelte";
+  import TempPrefixSelector from "./TempPrefixSelector.svelte";
+
+  let activeStepIndex = 0;
+
+  let hasLookupRan = false;
+  let showLoader = false;
+</script>
+
+<div class="wrapper">
+  <br />
+  <NotificationBar message="Metadata uploaded sucessfully!" />
+  <ScrollStepper bind:activeStepIndex displayPrevious={true}>
+    <ScrollStepperStep
+      title={`${
+        hasLookupRan ? "Re-select" : "Select"
+      } the Access Platform of the Items`}
+    >
+      <div slot="icon">1</div>
+      <div class="depositor-grid grid grid__col_2">
+        <TempPrefixSelector />
+        <button
+          class="primary"
+          on:click={() => {
+            showLoader = true;
+            setTimeout(() => {
+              activeStepIndex = 1;
+              hasLookupRan = true;
+              showLoader = false;
+            }, 2000);
+          }}
+        >
+          Look-up
+        </button>
+      </div>
+      <br />
+      <br />
+      {#if showLoader}
+        <div class="loading-wrap">
+          <Loading backgroundType="secondary" />
+        </div>
+      {:else if !hasLookupRan}
+        <table>
+          <thead>
+            <tr>
+              <th>Id</th>
+              <th>Label</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+          </tbody>
+        </table>
+      {/if}
+    </ScrollStepperStep>
+    <ScrollStepperStep
+      title="Update the Descriptive Metadata Records of the Items"
+      isLastStep={true}
+    >
+      <div slot="icon">2</div>
+
+      <div class="update-wrap">
+        <div class="update-grid grid grid__col_3">
+          <span>
+            <label for="access">Update in access</label>
+            <input name="access" type="checkbox" checked />
+          </span>
+          <span>
+            <label for="preservation">Update in preservation</label>
+            <input name="preservation" type="checkbox" checked />
+          </span>
+          <button class="primary">Update Descriptive Metadata Records</button>
+        </div>
+        <br />
+        <table>
+          <thead>
+            <tr>
+              <th>Id</th>
+              <th>Label</th>
+              <th>Value</th>
+              <th>In Access?</th>
+              <th>In Preservation?</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+            <tr>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+              <td>value</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </ScrollStepperStep>
+  </ScrollStepper>
+</div>
+
+<style>
+  .loading-wrap {
+    margin: auto;
+  }
+  .depositor-grid,
+  .loading-wrap {
+    width: fit-content;
+    margin-top: var(--perfect-fourth-4);
+    margin-bottom: var(--perfect-fourth-4);
+  }
+  .update-wrap {
+    min-height: 70rem;
+  }
+</style>

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -17,6 +17,7 @@
 
   let activeStepIndex = 0;
   let hasLookupRan = false;
+  let showLookup = true;
   let showLoader = false;
 
   export let dmdTask:
@@ -95,60 +96,961 @@
         label: "Vol. I, No. 1 (October 17, 1891)",
         parsed: true,
       },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
+      {
+        message: `{
+    "_id": "6116ba28948421e08ac27da1",
+    "index": 0,
+    "guid": "3ed1c087-e10b-4fae-b160-295a6c4ebab2",
+    "isActive": false,
+    "balance": "$3,247.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "blue",
+    "name": "Tasha Vazquez",
+    "gender": "female",
+    "company": "LIQUICOM",
+    "email": "tashavazquez@liquicom.com",
+    "phone": "+1 (926) 519-2616",
+    "address": "149 Hampton Avenue, Convent, Wyoming, 9623",
+    "about": "Cupidatat culpa officia proident sint irure pariatur eiusmod magna do ullamco commodo. Ut nostrud sunt aliqua anim et deserunt ut sit eiusmod aute. Lorem proident sint anim anim officia dolore ut officia mollit ullamco ex veniam. Veniam qui aliquip nulla deserunt do. Nostrud dolore sit dolore velit.",
+    "registered": "2021-04-13T05:35:59 +04:00",
+    "latitude": -62.302263,
+    "longitude": 93.035148,
+    "tags": [
+      "proident",
+      "laboris",
+      "aliqua",
+      "id",
+      "nisi",
+      "nostrud",
+      "qui"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herminia Cobb"
+      },
+      {
+        "id": 1,
+        "name": "Maldonado Pitts"
+      },
+      {
+        "id": 2,
+        "name": "Hardy Branch"
+      },
+      [
+      {
+        "id": 1234,
+        "name": "moo"
+      }]
+    ],
+    "greeting": "Hello, Tasha Vazquez! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  }`,
+        id: "8_06941_1",
+        label: "Vol. I, No. 1 (October 17, 1891)",
+        parsed: true,
+      },
     ],
   };
 </script>
+
+<div class="wrapper">
+  <!--OPTION B-->
+  <ScrollStepper bind:activeStepIndex displayPrevious={true}>
+    <ScrollStepperStep
+      title={`Look up items in their access platform${
+        hasLookupRan ? " again:" : ":"
+      }`}
+    >
+      <div slot="icon">1</div>
+      <div class="depositor-grid grid grid__col_2">
+        <TempPrefixSelector bind:prefix />
+        {#if prefix?.length}
+          <!--button
+            class="primary"
+            on:click={() => {
+              showLoader = true;
+              setTimeout(() => {
+                activeStepIndex = 1;
+                for (const item of dmdTask["items"]) {
+                  item["access"] = true;
+                  item["preservation"] = true;
+                }
+                dmdTask = dmdTask;
+                hasLookupRan = true;
+                showLoader = false;
+              }, 2000);
+            }}
+          >
+            Look-up
+          </button-->
+          <button
+            class="primary"
+            on:click={() => {
+              for (const item of dmdTask["items"]) {
+                delete item["access"];
+                delete item["preservation"];
+              }
+              dmdTask = dmdTask;
+              showLoader = true;
+              setTimeout(() => {
+                activeStepIndex = 1;
+                for (const item of dmdTask["items"]) {
+                  item["access"] = true;
+                  item["preservation"] = true;
+                }
+                dmdTask = dmdTask;
+                hasLookupRan = true;
+                showLoader = false;
+                showLookup = false;
+              }, 12000);
+            }}
+          >
+            <span
+              class="auto-align auto-align__a-center"
+              class:loading-button={showLoader}
+            >
+              {#if showLoader}
+                <Loading size="sm" />
+              {/if}
+              <span class="text"
+                >{!showLoader
+                  ? hasLookupRan
+                    ? "Look-up Again"
+                    : "Look-up"
+                  : "Looking-up..."}</span
+              >
+            </span>
+          </button>
+        {/if}
+      </div>
+      <!--{#if showLoader}
+        <br />
+        <br />
+        <div class="loading-wrap">
+          <Loading backgroundType="secondary" />
+        </div-->
+      {#if !hasLookupRan}
+        <DmdItemsTable bind:dmdTask />
+      {/if}
+    </ScrollStepperStep>
+    <ScrollStepperStep
+      title="Update the descriptive metadata records of the items:"
+      isLastStep={true}
+    >
+      <div slot="icon">2</div>
+      {#if !showLoader}
+        <div class="update-wrap">
+          <div class="update-grid grid grid__col_3">
+            <span>
+              <label for="access">Update in access</label>
+              <input
+                name="access"
+                type="checkbox"
+                bind:checked={shouldUpdateInAccess}
+              />
+            </span>
+            <span>
+              <label for="preservation">Update in preservation</label>
+              <input
+                name="preservation"
+                type="checkbox"
+                bind:checked={shouldUpdateInPreservation}
+              />
+            </span>
+            {#if shouldUpdateInAccess || shouldUpdateInPreservation}
+              <button class="primary"
+                >Update Descriptive Metadata Records</button
+              >
+            {/if}
+          </div>
+          <br />
+          <DmdItemsTable bind:dmdTask />
+        </div>
+      {/if}
+    </ScrollStepperStep>
+  </ScrollStepper>
+</div>
 
 <!--
   Todo: hide access selector if has run = until user click edit icon on found in access
   pass actual access name to table
   cleanup
   document
+  <NotificationBar message=""/>"
 -->
-<div class="wrapper">
-  <NotificationBar message="Metadata uploaded sucessfully!" />
 
-  <div class="depositor-grid grid grid__col_2">
-    <TempPrefixSelector bind:prefix />
-    {#if prefix?.length}
-      <button
-        class="primary"
-        on:click={() => {
-          for (const item of dmdTask["items"]) {
-            delete item["access"];
-            delete item["preservation"];
-          }
-          dmdTask = dmdTask;
-          showLoader = true;
-          setTimeout(() => {
+<!--div class="hero hero__gradient">
+  <div class="wrapper">
+    <h3>Metadata uploaded sucessfully!</h3>
+    <div class="auto-align auto-align__a-center">
+      <div class="tab active">Lookup</div>
+      <div class="tab">Update</div>
+    </div>
+  </div>
+</div>
+
+<div class="wrapper">
+  {#if showLookup}
+    <div class="depositor-grid grid grid__col_2">
+      <TempPrefixSelector bind:prefix />
+      {#if prefix?.length}
+        <button
+          class="primary"
+          on:click={() => {
             for (const item of dmdTask["items"]) {
-              item["access"] = true;
-              item["preservation"] = true;
+              delete item["access"];
+              delete item["preservation"];
             }
             dmdTask = dmdTask;
-            hasLookupRan = true;
-            showLoader = false;
-          }, 12000);
-        }}
-      >
-        <span
-          class="auto-align  auto-align__a-center"
-          class:loading-button={showLoader}
+            showLoader = true;
+            setTimeout(() => {
+              for (const item of dmdTask["items"]) {
+                item["access"] = true;
+                item["preservation"] = true;
+              }
+              dmdTask = dmdTask;
+              hasLookupRan = true;
+              showLoader = false;
+              showLookup = false;
+            }, 12000);
+          }}
         >
-          {#if showLoader}
-            <Loading size="sm" />
-          {/if}
-          <span class="text"
-            >{!showLoader
-              ? hasLookupRan
-                ? "Look-up Again"
-                : "Look-up"
-              : "Looking-up..."}</span
+          <span
+            class="auto-align auto-align__a-center"
+            class:loading-button={showLoader}
           >
-        </span>
-      </button>
-    {/if}
-  </div>
+            {#if showLoader}
+              <Loading size="sm" />
+            {/if}
+            <span class="text"
+              >{!showLoader
+                ? hasLookupRan
+                  ? "Look-up Again"
+                  : "Look-up"
+                : "Looking-up..."}</span
+            >
+          </span>
+        </button>
+      {/if}
+    </div>
+  {/if}
 
   {#if hasLookupRan}
     <div>
@@ -173,21 +1075,34 @@
           <button class="primary">Update Descriptive Metadata Records</button>
         {/if}
       </div>
-      <br />
     </div>
   {/if}
   <DmdItemsTable bind:dmdTask />
-</div>
-
+</div-->
 <style>
+  .hero {
+    padding: 0 !important;
+  }
+  .hero h3 {
+    padding: var(--perfect-fourth-2) 0 var(--perfect-fourth-4) 0 !important;
+  }
+  /*.tab {
+    min-width: 20rem;
+    padding: var(--perfect-fourth-7) 0;
+    text-align: center;
+  }
+  .tab.active {
+    border-bottom: 0.4rem solid #35c7d8;
+    background: #ffffff29;
+  }*/
   .loading-wrap {
     margin: auto;
   }
   .depositor-grid,
+  .update-grid,
   .loading-wrap {
-    width: fit-content;
-    margin-top: var(--perfect-fourth-4);
-    margin-bottom: var(--perfect-fourth-4);
+    margin-top: var(--perfect-fourth-8);
+    margin-bottom: var(--perfect-fourth-8);
   }
   .update-wrap {
     min-height: 70rem;

--- a/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitSuccessStoreForm.svelte
@@ -873,7 +873,7 @@
 <!--OPTION B-->
 <div class="wrapper">
   <br />
-  <NotificationBar message="Metadata uploaded successfully!" />
+  <!--NotificationBar message="Metadata uploaded successfully!" /-->
   <br />
 
   <div class="auto-align">

--- a/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
@@ -10,7 +10,7 @@ Displays a dmd task in an waiting state.
 
 ### Usage
 ```
-  <DmdSplitWaitingViewer {dmdTask} />
+<DmdSplitWaitingViewer {dmdTask} />
 ```
 -->
 <script lang="ts">

--- a/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
@@ -1,35 +1,8 @@
-<!--
-@component
-### Overview
-Displays a dmd task in an waiting state.
-
-### Properties
-|    |    |    |
-| -- | -- | -- |
-| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
-
-### Usage
-```
-<DmdSplitWaitingViewer {dmdTask} />
-```
--->
-<script lang="ts">
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
+<script>
   import DmdTaskTimeInfoTable from "$lib/components/dmd/DmdTaskTimeInfoTable.svelte";
   import Loading from "$lib/components/shared/Loading.svelte";
 
-  /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
-   */
-  export let dmdTask:
-    | WaitingDMDTask
-    | FailedDMDTask
-    | SucceededDMDTask
-    | undefined;
+  export let dmdTask;
 </script>
 
 <div class="hero hero__gradient full-page">
@@ -44,7 +17,7 @@ Displays a dmd task in an waiting state.
     <div
       class="auto-align auto-align__block auto-align__column auto-align__a-center"
     >
-      <h6>Please wait while the metadata upload processes...</h6>
+      <h6>Please wait while your DMD Task is processing...</h6>
       <DmdTaskTimeInfoTable {dmdTask} />
     </div>
   </div>

--- a/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
@@ -1,8 +1,35 @@
-<script>
+<!--
+@component
+### Overview
+Displays a dmd task in an waiting state.
+
+### Properties
+|    |    |    |
+| -- | -- | -- |
+| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
+
+### Usage
+```
+  <DmdSplitWaitingViewer {dmdTask} />
+```
+-->
+<script lang="ts">
+  import type {
+    WaitingDMDTask,
+    FailedDMDTask,
+    SucceededDMDTask,
+  } from "@crkn-rcdr/access-data";
   import DmdTaskTimeInfoTable from "$lib/components/dmd/DmdTaskTimeInfoTable.svelte";
   import Loading from "$lib/components/shared/Loading.svelte";
 
-  export let dmdTask;
+  /**
+   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
+   */
+  export let dmdTask:
+    | WaitingDMDTask
+    | FailedDMDTask
+    | SucceededDMDTask
+    | undefined;
 </script>
 
 <div class="hero hero__gradient full-page">

--- a/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
@@ -1,32 +1,5 @@
-<!--
-@component
-### Overview
-Displays a dmd task's time based information in a table, the user sees the task request date and the process last updated date.
-
-### Properties
-|    |    |    |
-| -- | -- | -- |
-| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
-
-### Usage
-```
-<DmdTaskTimeInfoTable {dmdTask} />
-```
--->
-<script lang="ts">
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
-  /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
-   */
-  export let dmdTask:
-    | WaitingDMDTask
-    | FailedDMDTask
-    | SucceededDMDTask
-    | undefined;
+<script>
+  export let dmdTask;
 </script>
 
 <div class="dmd-request-info">

--- a/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
@@ -29,7 +29,7 @@ Displays a dmd task's time based information in a table, the user sees the task 
     | undefined;
 </script>
 
-<div class="dmd-request-info">
+<div class="dmd-request-info grid grid__col_2">
   <span>Request inititated:</span>
   <span>{dmdTask?.["updated"]}</span>
   <span>Request updated:</span>
@@ -39,11 +39,6 @@ Displays a dmd task's time based information in a table, the user sees the task 
 <style>
   .dmd-request-info {
     width: fit-content;
-    display: inline-grid;
-    display: grid;
-    grid-template-areas: "a a";
-    gap: 2rem;
-    align-items: center;
     margin-top: var(--perfect-fourth-4);
     margin-bottom: var(--perfect-fourth-4);
   }

--- a/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
@@ -1,5 +1,32 @@
-<script>
-  export let dmdTask;
+<!--
+@component
+### Overview
+Displays a dmd task's time based information in a table, the user sees the task request date and the process last updated date.
+
+### Properties
+|    |    |    |
+| -- | -- | -- |
+| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
+
+### Usage
+```
+<DmdTaskTimeInfoTable {dmdTask} />
+```
+-->
+<script lang="ts">
+  import type {
+    WaitingDMDTask,
+    FailedDMDTask,
+    SucceededDMDTask,
+  } from "@crkn-rcdr/access-data";
+  /**
+   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
+   */
+  export let dmdTask:
+    | WaitingDMDTask
+    | FailedDMDTask
+    | SucceededDMDTask
+    | undefined;
 </script>
 
 <div class="dmd-request-info">

--- a/services/admin/src/lib/components/dmd/TempPrefixSelector.svelte
+++ b/services/admin/src/lib/components/dmd/TempPrefixSelector.svelte
@@ -80,6 +80,5 @@ Allows the user to select one of many pre-defined depositors.
 <style>
   select {
     width: 100%;
-    max-width: 30rem;
   }
 </style>

--- a/services/admin/src/lib/components/dmd/TempPrefixSelector.svelte
+++ b/services/admin/src/lib/components/dmd/TempPrefixSelector.svelte
@@ -80,5 +80,6 @@ Allows the user to select one of many pre-defined depositors.
 <style>
   select {
     width: 100%;
+    max-width: 30rem;
   }
 </style>

--- a/services/admin/src/lib/components/dmd/TempPrefixSelector.svelte
+++ b/services/admin/src/lib/components/dmd/TempPrefixSelector.svelte
@@ -1,0 +1,84 @@
+<!--
+@component
+### Overview
+Allows the user to select one of many pre-defined depositors.
+### Properties
+|    |    |    |
+| -- | -- | -- |
+| prefix: string    | optional | The prefix that is selected in the selection element |
+### Usage
+```  
+<DmdPrefixSelector bind:prefix={depositorPrefix} />
+```
+*Note: `bind:` is required for changes to the parameters to be reflected in higher level components.*
+-->
+<script lang="ts">
+  import type { Depositor } from "$lib/types";
+  /**
+   * @type {string} The prefix that is selected in the selection element |
+   */
+  export let prefix: string;
+  // TODO: add period to end of each prefix?
+  /**
+   * @type { Array<Depositor>} The array of prefix opetions for the selection element.
+   */
+  const prefixes: Array<Depositor> = [
+    {
+      string: "ams",
+      label: "Shortgrass Public Library System",
+    },
+    {
+      string: "omcn",
+      label: "Mississauga Library System",
+    },
+    {
+      string: "oocihm",
+      label: "Canadiana.org",
+    },
+    {
+      string: "ooe",
+      label: "Department of Foreign Affairs Trade and Development",
+    },
+    {
+      string: "oop",
+      label: "Library of Parliament",
+    },
+    {
+      string: "carl",
+      label: "Canadian Association of Research Libraries",
+    },
+    {
+      string: "numeris",
+      label: "Numeris - broadcast measurement and consumer behaviour data",
+    },
+    {
+      string: "osmsdga",
+      label: "South Mountain",
+    },
+    {
+      string: "ooga",
+      label: "Canadian Hazards Information Service",
+    },
+    {
+      string: "qmma",
+      label: "McGill University Archives",
+    },
+    {
+      string: "490",
+      label: "MARC File",
+    },
+  ];
+</script>
+
+<select name="depositor" bind:value={prefix}>
+  <option value="">Select an access platform:</option>
+  {#each prefixes as prefix}
+    <option value={prefix.string}>{prefix.label} ({prefix.string})</option>
+  {/each}
+</select>
+
+<style>
+  select {
+    width: 100%;
+  }
+</style>

--- a/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
+++ b/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
@@ -253,6 +253,7 @@ This component allows the user to search through other manifests and select canv
   .canvas-selector-wrap {
     position: relative;
     height: 100%;
+    background-color: var(--backdrop-bg);
   }
 
   .add-menu-title {
@@ -267,7 +268,7 @@ This component allows the user to search through other manifests and select canv
     width: 100%;
     height: fit-content;
     padding-top: 0.5rem;
-    background: #222;
+    background: var(--darkest-bg);
     z-index: 1;
     color: var(--light-font);
     padding: 0.7rem;

--- a/services/admin/src/lib/components/shared/JsonTree.svelte
+++ b/services/admin/src/lib/components/shared/JsonTree.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import IoMdArrowDropright from "svelte-icons/io/IoMdArrowDropright.svelte";
+  import IoMdArrowDropdown from "svelte-icons/io/IoMdArrowDropdown.svelte";
+  /**
+   * @see https://svelte.dev/repl/347b37e18b5d4a65bbacfd097536db02?version=3.24.0
+   */
+  export let value: any;
+  export let key = "";
+  export let indent = 0;
+  export let open = true;
+
+  function toggleOpen() {
+    open = !open;
+  }
+</script>
+
+<div
+  class="json-wrap auto-align auto-align__a-center auto-align__block auto-align__wrap"
+  style="padding-left: {indent}rem"
+>
+  {#if key?.length}
+    <span
+      on:click={toggleOpen}
+      class="expander auto-align auto-align__a-center"
+    >
+      {#if open}
+        <span class="icon">
+          <IoMdArrowDropdown />
+        </span>
+      {:else}
+        <span class="icon">
+          <IoMdArrowDropright />
+        </span>
+      {/if}
+      <span class="key">{key}:</span>
+    </span>
+  {/if}
+  {#if open}
+    {#if typeof value === "object"}
+      <br />
+      {#if Array.isArray(value)}
+        {#each value as item}
+          {#if typeof item === "object"}
+            <svelte:self
+              key={Array.isArray(item) ? "array" : "object"}
+              value={item}
+              indent={indent + 1}
+            />
+          {:else}
+            <svelte:self value={item} indent={indent + 1} />
+          {/if}
+        {/each}
+      {:else}
+        {#each Object.keys(value) as key}
+          <svelte:self {key} value={value[key]} indent={indent + 1} />
+        {/each}
+      {/if}
+    {:else}
+      <span class={typeof value}>&nbsp;{value}</span>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .json-wrap {
+    width: 100%;
+  }
+
+  .expander {
+    cursor: pointer;
+    user-select: none;
+  }
+
+  :global(.json-wrap .string) {
+    color: var(--secondary);
+  }
+  :global(.json-wrap .number) {
+    color: black;
+  }
+  :global(.json-wrap .boolean) {
+    color: purple;
+  }
+  :global(.json-wrap .null) {
+    color: red;
+  }
+  :global(.json-wrap .key) {
+    color: var(--primary);
+  }
+</style>

--- a/services/admin/src/lib/components/shared/Loading.svelte
+++ b/services/admin/src/lib/components/shared/Loading.svelte
@@ -23,9 +23,11 @@ This component shows a CRKN-esque loader to be used when an action is being perf
     | "primary"
     | "secondary"
     | "gradient" = "light";
+
+  export let size: "sm" | "md" | "lg" = "md";
 </script>
 
-<div class="loader auto-align auto-align__a-center">
+<div class={`loader ${size} auto-align auto-align__a-center`}>
   <div class={`line line__${backgroundType}`} />
   <div class={`line line__${backgroundType}`} />
   <div class={`line line__${backgroundType}`} />
@@ -33,27 +35,68 @@ This component shows a CRKN-esque loader to be used when an action is being perf
 
 <style>
   .loader {
-    height: 4rem;
     width: fit-content;
+  }
+  .loader.lg {
+    height: 10rem;
+  }
+  .loader.md {
+    height: 4rem;
+  }
+  .loader.sm {
+    height: 1rem;
   }
   .loader:last-child {
     margin-right: 0 !important;
   }
-  .loader .line:nth-last-child(1) {
-    animation: growShrink 2s 1s infinite;
+  .loader.lg .line:nth-last-child(1) {
+    animation: growShrinkLg 2s 1s infinite;
   }
-  .loader .line:nth-last-child(2) {
-    animation: growShrink 2s 0.5s infinite;
+  .loader.lg .line:nth-last-child(2) {
+    animation: growShrinkLg 2s 0.5s infinite;
   }
-  .loader .line:nth-last-child(3) {
-    animation: growShrink 2s 0s infinite;
+  .loader.lg .line:nth-last-child(3) {
+    animation: growShrinkLg 2s 0s infinite;
   }
+  .loader.md .line:nth-last-child(1) {
+    animation: growShrinkMd 2s 1s infinite;
+  }
+  .loader.md .line:nth-last-child(2) {
+    animation: growShrinkMd 2s 0.5s infinite;
+  }
+  .loader.md .line:nth-last-child(3) {
+    animation: growShrinkMd 2s 0s infinite;
+  }
+  .loader.sm .line:nth-last-child(1) {
+    animation: growShrinkSm 2s 1s infinite;
+  }
+  .loader.sm .line:nth-last-child(2) {
+    animation: growShrinkSm 2s 0.5s infinite;
+  }
+  .loader.sm .line:nth-last-child(3) {
+    animation: growShrinkSm 2s 0s infinite;
+  }
+
   .line {
     display: inline-block;
+  }
+  .loader.lg .line {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 3rem;
+    margin-right: var(--margin-sm);
+  }
+  .loader.md .line {
     width: 1rem;
     height: 1rem;
     border-radius: 1rem;
     margin-right: var(--margin-sm);
+  }
+  .loader.sm .line {
+    width: 0.2rem;
+    height: 0.2rem;
+    border-radius: 0.2rem;
+    margin-right: 0.3rem;
   }
   .line__primary {
     background: var(--primary);
@@ -74,7 +117,18 @@ This component shows a CRKN-esque loader to be used when an action is being perf
       var(--green) 93.69%
     );
   }
-  @keyframes growShrink {
+  @keyframes growShrinkLg {
+    0% {
+      height: 3rem;
+    }
+    50% {
+      height: 9rem;
+    }
+    100% {
+      height: 3rem;
+    }
+  }
+  @keyframes growShrinkMd {
     0% {
       height: 1rem;
     }
@@ -83,6 +137,17 @@ This component shows a CRKN-esque loader to be used when an action is being perf
     }
     100% {
       height: 1rem;
+    }
+  }
+  @keyframes growShrinkSm {
+    0% {
+      height: 0.2rem;
+    }
+    50% {
+      height: 0.6rem;
+    }
+    100% {
+      height: 0.2rem;
     }
   }
 </style>

--- a/services/admin/src/lib/components/shared/Modal.svelte
+++ b/services/admin/src/lib/components/shared/Modal.svelte
@@ -8,6 +8,7 @@ A component that overlays ontop of the application, in the center of the screen.
 | -- | -- | -- |
 | open : boolean    | required | The state control for showing or hiding the modal |
 | title : string    | optional | The title text of the modal. |
+| size : "sm" or "md" or "lg"   | optional | The size setting for the modal. |
 
 ### Usage
 ```  
@@ -26,7 +27,7 @@ A component that overlays ontop of the application, in the center of the screen.
 *Note: `bind:` is required for changes to the object and its model to be reflected in higher level components.*
 
 -->
-<script>
+<script lang="ts">
   import TiTimes from "svelte-icons/ti/TiTimes.svelte";
 
   /**
@@ -37,14 +38,32 @@ A component that overlays ontop of the application, in the center of the screen.
   /**
    * @type {string} The title text of the modal.
    */
-  export let title = "Modal";
+  export let title = "";
+
+  /**
+   * @type {"sm" | "md" | "lg"} The title text of the modal.
+   */
+  export let size: "sm" | "md" | "lg" = "sm";
+
+  let body: HTMLBodyElement;
+
+  $: {
+    if (body) {
+      if (open) {
+        body.classList.add("no-scroll"); //`height: 100%;overflow: hidden;`;
+      } else {
+        body.classList.remove("no-scroll");
+      }
+    }
+  }
 </script>
 
+<svelte:body bind:this={body} />
 {#if open}
   <div
     class="modal-backdrop auto-align auto_align__full auto-align__a-center auto-align__j-center"
   >
-    <div class="modal">
+    <div class={`modal ${size}`}>
       <div class="modal-inner">
         <div class="modal-header auto-align">
           <h6>{title}</h6>
@@ -86,11 +105,28 @@ A component that overlays ontop of the application, in the center of the screen.
   .modal {
     position: relative;
     background-color: var(--base-bg);
+    text-align: left;
+  }
+
+  .modal.sm {
     width: 50rem;
     max-width: 100%;
     height: 25rem;
     max-height: 100%;
-    text-align: left;
+  }
+
+  .modal.md {
+    width: 65rem;
+    max-width: 100%;
+    height: 50rem;
+    max-height: 100%;
+  }
+
+  .modal.lg {
+    width: 85rem;
+    max-width: 100%;
+    height: 75rem;
+    max-height: 100%;
   }
 
   .modal-inner {
@@ -124,10 +160,10 @@ A component that overlays ontop of the application, in the center of the screen.
 
   .modal-footer {
     grid-area: footer;
-    /*position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: var(--perfect-fourth-6);*/
+  }
+
+  :global(body.no-scroll) {
+    height: 100vh;
+    overflow: hidden;
   }
 </style>

--- a/services/admin/src/lib/components/shared/ScrollStepper.svelte
+++ b/services/admin/src/lib/components/shared/ScrollStepper.svelte
@@ -124,22 +124,21 @@ The scroll stepper component is a component that breaks down a long task into sm
     let steps = container.getElementsByClassName("scroll-stepper-step");
     for (let i = 0; i < steps.length; i++) {
       if (displayPrevious ? i <= activeStepIndex : i === activeStepIndex) {
-        steps[i].classList.add("show");
         steps[i].classList.remove("hide");
       } else {
         steps[i].classList.add("hide");
-        steps[i].classList.remove("show");
       }
 
       if (i === activeStepIndex) {
         steps[i].classList.add("scroll-stepper-step-active");
-        if (i !== 0 && window) {
-          const offset = getOffset(steps[i]);
-          const y =
-            i === steps.length - 1
-              ? offset.top + steps[i].clientHeight
-              : offset.top - 20;
-          window.scrollTo({ top: y, behavior: "smooth" });
+        if (window && i !== 0) {
+          setTimeout(() => {
+            const offset = getOffset(steps[i]);
+            const y = offset.top - 20;
+            console.log(i === steps.length - 1, activeStepIndex, "SCROOLLL", y);
+            window.history.scrollRestoration = "manual";
+            window.scrollTo({ top: y, behavior: "smooth" });
+          }, 10);
         }
       } else {
         steps[i].classList.remove("scroll-stepper-step-active");

--- a/services/admin/src/lib/components/shared/ScrollStepper.svelte
+++ b/services/admin/src/lib/components/shared/ScrollStepper.svelte
@@ -47,6 +47,11 @@ The scroll stepper component is a component that breaks down a long task into sm
   export let displayPrevious: boolean = false;
 
   /**
+   * @type {boolean} If the stepper should scroll to the new active index automatically
+   */
+  export let enableAutoScrolling: boolean = true;
+
+  /**
    * @type {HTMLDivElement} This container element holds the drop down menu items
    */
   let container: HTMLDivElement;
@@ -124,14 +129,14 @@ The scroll stepper component is a component that breaks down a long task into sm
     let steps = container.getElementsByClassName("scroll-stepper-step");
     for (let i = 0; i < steps.length; i++) {
       if (displayPrevious ? i <= activeStepIndex : i === activeStepIndex) {
-        steps[i].classList.remove("hide");
+        steps[i].classList.add("show");
       } else {
-        steps[i].classList.add("hide");
+        steps[i].classList.remove("show");
       }
 
       if (i === activeStepIndex) {
         steps[i].classList.add("scroll-stepper-step-active");
-        if (window && i !== 0) {
+        if (enableAutoScrolling && window && i !== 0) {
           setTimeout(() => {
             const offset = getOffset(steps[i]);
             const y = offset.top - 20;

--- a/services/admin/src/lib/components/shared/ScrollStepperStep.svelte
+++ b/services/admin/src/lib/components/shared/ScrollStepperStep.svelte
@@ -50,7 +50,7 @@ A step (section) of a ScrollStepper. Generally used to isolate a group of requir
   class="scroll-stepper-step"
   class:scroll-stepper-step-not-last={!isLastStep}
 >
-  <h6
+  <span
     class="scroll-stepper-step-title auto-align auto-align__block auto-align__a-center"
   >
     <div
@@ -59,7 +59,7 @@ A step (section) of a ScrollStepper. Generally used to isolate a group of requir
       <slot name="icon" />
     </div>
     {title}
-  </h6>
+  </span>
   <div class="scroll-stepper-step-body">
     <slot />
   </div>
@@ -69,8 +69,10 @@ A step (section) of a ScrollStepper. Generally used to isolate a group of requir
   .scroll-stepper-step-not-last::before {
     content: "";
     position: absolute;
-    top: 8.7rem;
-    bottom: -5rem;
+    /*top: 8.7rem;
+    bottom: -5rem;*/
+    top: 4.7rem;
+    bottom: 0rem;
     width: 1px;
     background-color: rgba(0, 0, 0, 0.2);
     left: 1.4rem;
@@ -78,13 +80,13 @@ A step (section) of a ScrollStepper. Generally used to isolate a group of requir
   }
   .scroll-stepper-step {
     position: relative;
-    padding: var(--perfect-fourth-2) 0;
+    padding: 0 0 var(--perfect-fourth-2) 0; /*var(--perfect-fourth-2) 0;*/
     /*z-index: 1;*/
   }
-  :global(.scroll-stepper-step .scroll-stepper-step-body) {
+  :global(.scroll-stepper-step.show .scroll-stepper-step-body) {
     display: block;
   }
-  :global(.scroll-stepper-step.hide .scroll-stepper-step-body) {
+  :global(.scroll-stepper-step .scroll-stepper-step-body) {
     display: none;
   }
   h6 {

--- a/services/admin/src/lib/components/shared/ScrollStepperStep.svelte
+++ b/services/admin/src/lib/components/shared/ScrollStepperStep.svelte
@@ -81,7 +81,7 @@ A step (section) of a ScrollStepper. Generally used to isolate a group of requir
     padding: var(--perfect-fourth-2) 0;
     /*z-index: 1;*/
   }
-  :global(.scroll-stepper-step.show .scroll-stepper-step-body) {
+  :global(.scroll-stepper-step .scroll-stepper-step-body) {
     display: block;
   }
   :global(.scroll-stepper-step.hide .scroll-stepper-step-body) {

--- a/services/admin/src/lib/components/shared/ScrollStepperStep.svelte
+++ b/services/admin/src/lib/components/shared/ScrollStepperStep.svelte
@@ -79,7 +79,7 @@ A step (section) of a ScrollStepper. Generally used to isolate a group of requir
   .scroll-stepper-step {
     position: relative;
     padding: var(--perfect-fourth-2) 0;
-    z-index: 1;
+    /*z-index: 1;*/
   }
   :global(.scroll-stepper-step.show .scroll-stepper-step-body) {
     display: block;

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -40,8 +40,8 @@
     mdType: "marcooe",
     process: {
       requestDate: "1628785101",
-      succeeded: false,
-      message: "The process.message from the backend",
+      //succeeded: false,
+      //message: "The process.message from the backend",
     },
     //items: [{}],
   };

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -40,8 +40,8 @@
     mdType: "marcooe",
     process: {
       requestDate: "1628785101",
-      //succeeded: true,
-      //message: "Bippidy Boppidy Boop",
+      succeeded: false,
+      message: "The process.message from the backend",
     },
     //items: [{}],
   };

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -40,10 +40,10 @@
     mdType: "marcooe",
     process: {
       requestDate: "1628785101",
-      //succeeded: false,
-      //message: "The process.message from the backend",
+      succeeded: true,
+      message: "The process.message from the backend",
     },
-    //items: [{}],
+    items: [{}],
   };
 </script>
 
@@ -71,7 +71,7 @@
     text-align: center;
     font-weight: bold;
   }
-  :global(.dmd-task-page-wrap .notification-bar) {
+  :global(.dmd-task-page-wrap .failure .notification-bar) {
     width: 30rem;
   }
 </style>

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -1,36 +1,16 @@
-<script context="module" lang="ts">
-  /**
-   * @module
-   * @description loads in the dmdtask from the backend using the params in the route of the page
-   */
-</script>
-
 <script lang="ts">
-  /**
-   * @file
-   * @description This page displays the various states of and information about a dmdtask
-   */
   import { getStores } from "$app/stores";
   import type { Session } from "$lib/types";
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
-  import DmdSplitWaitingViewer from "$lib/components/dmd/DmdSplitWaitingViewer.svelte";
-  import DmdSplitFailureViewer from "$lib/components/dmd/DmdSplitFailureViewer.svelte";
-  import DmdSplitSuccessStoreForm from "$lib/components/dmd/DmdSplitSuccessStoreForm.svelte";
+  import Loading from "$lib/components/shared/Loading.svelte";
+  import type { WaitingDMDTask } from "@crkn-rcdr/access-data";
 
   /**
    * @type {Session} The session store that contains the module for sending requests to lapin.
    */
   const { session } = getStores<Session>();
 
-  /* TODO: Later grab from backend. */
-  /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask} The dmdtask being displayed by the page.
-   */
-  const dmdTask: WaitingDMDTask | FailedDMDTask | SucceededDMDTask = {
+  /* Later grab from backend. */
+  const dmdTask: WaitingDMDTask = {
     id: "123",
     updated: "1628785112",
     attachments: {
@@ -40,38 +20,44 @@
     mdType: "marcooe",
     process: {
       requestDate: "1628785101",
-      //succeeded: false,
-      //message: "The process.message from the backend",
     },
-    //items: [{}],
   };
 </script>
 
-<div class="dmd-task-page-wrap">
-  {#if !("succeeded" in dmdTask?.["process"])}
-    <DmdSplitWaitingViewer {dmdTask} />
-  {:else if !dmdTask?.["process"]?.["succeeded"]}
-    <DmdSplitFailureViewer
-      {dmdTask}
-      message={dmdTask?.["process"]?.["message"]}
-    />
-  {:else if dmdTask?.["items"]?.length}
-    <DmdSplitSuccessStoreForm />
-  {:else}
-    <!--JUUUST In Case-->
-    <DmdSplitFailureViewer
-      {dmdTask}
-      message="No objects were split from the metadata file."
-    />
-  {/if}
+<div class="hero hero__gradient full-page">
+  <div class="wrapper">
+    <br />
+    <br />
+    <br />
+    <div class="auto-align auto-align__block auto-align__j-center">
+      <Loading />
+    </div>
+    <br />
+    <div
+      class="auto-align auto-align__block auto-align__column auto-align__a-center"
+    >
+      <h6>Please wait while your DMD Task is processing...</h6>
+      <div class="dmd-request-info">
+        <span>Request inititated:</span>
+        <span>{dmdTask?.["updated"]}</span>
+        <span>Request updated:</span>
+        <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+      </div>
+    </div>
+  </div>
 </div>
 
 <style>
-  :global(.dmd-task-page-wrap h6) {
+  h6 {
     text-align: center;
-    font-weight: bold;
   }
-  :global(.dmd-task-page-wrap .notification-bar) {
-    width: 30rem;
+  .dmd-request-info {
+    width: fit-content;
+    display: inline-grid;
+    display: grid;
+    grid-template-areas: "a a";
+    gap: 2rem;
+    align-items: center;
+    margin-top: var(--perfect-fourth-4);
   }
 </style>

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -18,6 +18,7 @@
     FailedDMDTask,
     SucceededDMDTask,
   } from "@crkn-rcdr/access-data";
+  import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
 
   /**
    * @type {Session} The session store that contains the module for sending requests to lapin.
@@ -38,43 +39,87 @@
     mdType: "marcooe",
     process: {
       requestDate: "1628785101",
+      // succeeded: true,
+      //message: "Bippidy Boppidy Boop",
     },
+    //items: [{}],
   };
 </script>
 
-{#if !dmdTask["split"]}
-  <!-- TODO: move to own component -->
-  <div class="hero hero__gradient full-page">
-    <div class="wrapper">
-      <br />
-      <br />
-      <br />
-      <div class="auto-align auto-align__block auto-align__j-center">
-        <Loading />
-      </div>
-      <br />
-      <div
-        class="auto-align auto-align__block auto-align__column auto-align__a-center"
-      >
-        <h6>Please wait while your DMD Task is processing...</h6>
-        <div class="dmd-request-info">
-          <span>Request inititated:</span>
-          <span>{dmdTask?.["updated"]}</span>
-          <span>Request updated:</span>
-          <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+<div class="dmd-task-page-wrap">
+  {#if !("succeeded" in dmdTask?.["process"])}
+    <!-- TODO: move to own component -->
+    <div class="hero hero__gradient full-page">
+      <div class="wrapper">
+        <br />
+        <br />
+        <br />
+        <div class="auto-align auto-align__block auto-align__j-center">
+          <Loading />
+        </div>
+        <br />
+        <div
+          class="auto-align auto-align__block auto-align__column auto-align__a-center"
+        >
+          <h6>Please wait while your DMD Task is processing...</h6>
+          <div class="dmd-request-info">
+            <span>Request inititated:</span>
+            <span>{dmdTask?.["updated"]}</span>
+            <span>Request updated:</span>
+            <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-{:else if !dmdTask?.["split"]?.["success"]}
-  fail
-{:else}
-  success!
-{/if}
+  {:else if !dmdTask?.["process"]?.["succeeded"]}
+    <div class="hero hero__gradient full-page failure">
+      <div class="wrapper">
+        <div
+          class="auto-align auto-align__block auto-align__column auto-align__a-center"
+        >
+          <h6>DMD Task Failed!</h6>
+          <NotificationBar
+            message={dmdTask?.["process"]?.["message"]}
+            status="fail"
+          />
+          <div class="dmd-request-info">
+            <span>Request inititated:</span>
+            <span>{dmdTask?.["updated"]}</span>
+            <span>Request updated:</span>
+            <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+          </div>
+          <a href="/dmd/new" class="dmd-task-try-again">
+            <button class="danger">Try Again</button>
+          </a>
+        </div>
+      </div>
+    </div>
+  {:else if dmdTask?.["items"]}
+    success!
+  {:else}
+    <div class="hero hero__gradient full-page failure">
+      <div class="wrapper">
+        <div
+          class="auto-align auto-align__block auto-align__column auto-align__a-center"
+        >
+          <h6>Oops!</h6>
+          <NotificationBar
+            message="We couldn't find any items to add metadata to from your file."
+            status="fail"
+          />
+          <a href="/dmd/new" class="dmd-task-try-again">
+            <button class="danger">Try Again</button>
+          </a>
+        </div>
+      </div>
+    </div>
+  {/if}
+</div>
 
 <style>
   h6 {
     text-align: center;
+    font-weight: bold;
   }
   .dmd-request-info {
     width: fit-content;
@@ -84,5 +129,19 @@
     gap: 2rem;
     align-items: center;
     margin-top: var(--perfect-fourth-4);
+    margin-bottom: var(--perfect-fourth-4);
+  }
+  .dmd-task-try-again {
+    margin-top: var(--perfect-fourth-4);
+    margin-bottom: var(--perfect-fourth-4);
+  }
+  .failure {
+    filter: hue-rotate(207deg);
+  }
+  .failure > * {
+    filter: hue-rotate(-207deg);
+  }
+  :global(.dmd-task-page-wrap .notification-bar) {
+    width: 30rem;
   }
 </style>

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -24,7 +24,10 @@
    */
   const { session } = getStores<Session>();
 
-  /* Later grab from backend. */
+  /* TODO: Later grab from backend. */
+  /**
+   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask} The dmdtask being displayed by the page.
+   */
   const dmdTask: WaitingDMDTask | FailedDMDTask | SucceededDMDTask = {
     id: "123",
     updated: "1628785112",
@@ -40,7 +43,7 @@
 </script>
 
 {#if !dmdTask["split"]}
-  <!-- TODO: move to component -->
+  <!-- TODO: move to own component -->
   <div class="hero hero__gradient full-page">
     <div class="wrapper">
       <br />

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -2,7 +2,11 @@
   import { getStores } from "$app/stores";
   import type { Session } from "$lib/types";
   import Loading from "$lib/components/shared/Loading.svelte";
-  import type { WaitingDMDTask } from "@crkn-rcdr/access-data";
+  import type {
+    WaitingDMDTask,
+    FailedDMDTask,
+    SucceededDMDTask,
+  } from "@crkn-rcdr/access-data";
 
   /**
    * @type {Session} The session store that contains the module for sending requests to lapin.
@@ -10,7 +14,7 @@
   const { session } = getStores<Session>();
 
   /* Later grab from backend. */
-  const dmdTask: WaitingDMDTask = {
+  const dmdTask: WaitingDMDTask | FailedDMDTask | SucceededDMDTask = {
     id: "123",
     updated: "1628785112",
     attachments: {
@@ -24,28 +28,35 @@
   };
 </script>
 
-<div class="hero hero__gradient full-page">
-  <div class="wrapper">
-    <br />
-    <br />
-    <br />
-    <div class="auto-align auto-align__block auto-align__j-center">
-      <Loading />
-    </div>
-    <br />
-    <div
-      class="auto-align auto-align__block auto-align__column auto-align__a-center"
-    >
-      <h6>Please wait while your DMD Task is processing...</h6>
-      <div class="dmd-request-info">
-        <span>Request inititated:</span>
-        <span>{dmdTask?.["updated"]}</span>
-        <span>Request updated:</span>
-        <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+{#if !dmdTask["split"]}
+  <!-- TODO: move to component -->
+  <div class="hero hero__gradient full-page">
+    <div class="wrapper">
+      <br />
+      <br />
+      <br />
+      <div class="auto-align auto-align__block auto-align__j-center">
+        <Loading />
+      </div>
+      <br />
+      <div
+        class="auto-align auto-align__block auto-align__column auto-align__a-center"
+      >
+        <h6>Please wait while your DMD Task is processing...</h6>
+        <div class="dmd-request-info">
+          <span>Request inititated:</span>
+          <span>{dmdTask?.["updated"]}</span>
+          <span>Request updated:</span>
+          <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+        </div>
       </div>
     </div>
   </div>
-</div>
+{:else if !dmdTask?.["split"]?.["success"]}
+  fail
+{:else}
+  success!
+{/if}
 
 <style>
   h6 {

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -1,4 +1,15 @@
+<script context="module" lang="ts">
+  /**
+   * @module
+   * @description loads in the dmdtask from the backend using the params in the route of the page
+   */
+</script>
+
 <script lang="ts">
+  /**
+   * @file
+   * @description This page displays the various states of and information about a dmdtask
+   */
   import { getStores } from "$app/stores";
   import type { Session } from "$lib/types";
   import Loading from "$lib/components/shared/Loading.svelte";

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -12,13 +12,14 @@
    */
   import { getStores } from "$app/stores";
   import type { Session } from "$lib/types";
-  import Loading from "$lib/components/shared/Loading.svelte";
   import type {
     WaitingDMDTask,
     FailedDMDTask,
     SucceededDMDTask,
   } from "@crkn-rcdr/access-data";
-  import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
+  import DmdSplitWaitingViewer from "$lib/components/dmd/DmdSplitWaitingViewer.svelte";
+  import DmdSplitFailureViewer from "$lib/components/dmd/DmdSplitFailureViewer.svelte";
+  import DmdSplitSuccessStoreForm from "$lib/components/dmd/DmdSplitSuccessStoreForm.svelte";
 
   /**
    * @type {Session} The session store that contains the module for sending requests to lapin.
@@ -39,7 +40,7 @@
     mdType: "marcooe",
     process: {
       requestDate: "1628785101",
-      // succeeded: true,
+      //succeeded: true,
       //message: "Bippidy Boppidy Boop",
     },
     //items: [{}],
@@ -48,98 +49,27 @@
 
 <div class="dmd-task-page-wrap">
   {#if !("succeeded" in dmdTask?.["process"])}
-    <!-- TODO: move to own component -->
-    <div class="hero hero__gradient full-page">
-      <div class="wrapper">
-        <br />
-        <br />
-        <br />
-        <div class="auto-align auto-align__block auto-align__j-center">
-          <Loading />
-        </div>
-        <br />
-        <div
-          class="auto-align auto-align__block auto-align__column auto-align__a-center"
-        >
-          <h6>Please wait while your DMD Task is processing...</h6>
-          <div class="dmd-request-info">
-            <span>Request inititated:</span>
-            <span>{dmdTask?.["updated"]}</span>
-            <span>Request updated:</span>
-            <span>{dmdTask?.["process"]?.["requestDate"]}</span>
-          </div>
-        </div>
-      </div>
-    </div>
+    <DmdSplitWaitingViewer {dmdTask} />
   {:else if !dmdTask?.["process"]?.["succeeded"]}
-    <div class="hero hero__gradient full-page failure">
-      <div class="wrapper">
-        <div
-          class="auto-align auto-align__block auto-align__column auto-align__a-center"
-        >
-          <h6>DMD Task Failed!</h6>
-          <NotificationBar
-            message={dmdTask?.["process"]?.["message"]}
-            status="fail"
-          />
-          <div class="dmd-request-info">
-            <span>Request inititated:</span>
-            <span>{dmdTask?.["updated"]}</span>
-            <span>Request updated:</span>
-            <span>{dmdTask?.["process"]?.["requestDate"]}</span>
-          </div>
-          <a href="/dmd/new" class="dmd-task-try-again">
-            <button class="danger">Try Again</button>
-          </a>
-        </div>
-      </div>
-    </div>
-  {:else if dmdTask?.["items"]}
-    success!
+    <DmdSplitFailureViewer
+      {dmdTask}
+      message={dmdTask?.["process"]?.["message"]}
+    />
+  {:else if dmdTask?.["items"]?.length}
+    <DmdSplitSuccessStoreForm />
   {:else}
-    <div class="hero hero__gradient full-page failure">
-      <div class="wrapper">
-        <div
-          class="auto-align auto-align__block auto-align__column auto-align__a-center"
-        >
-          <h6>Oops!</h6>
-          <NotificationBar
-            message="We couldn't find any items to add metadata to from your file."
-            status="fail"
-          />
-          <a href="/dmd/new" class="dmd-task-try-again">
-            <button class="danger">Try Again</button>
-          </a>
-        </div>
-      </div>
-    </div>
+    <!--JUUUST In Case-->
+    <DmdSplitFailureViewer
+      {dmdTask}
+      message="No objects were split from the metadata file."
+    />
   {/if}
 </div>
 
 <style>
-  h6 {
+  :global(.dmd-task-page-wrap h6) {
     text-align: center;
     font-weight: bold;
-  }
-  .dmd-request-info {
-    width: fit-content;
-    display: inline-grid;
-    display: grid;
-    grid-template-areas: "a a";
-    gap: 2rem;
-    align-items: center;
-    margin-top: var(--perfect-fourth-4);
-    margin-bottom: var(--perfect-fourth-4);
-  }
-  .dmd-task-try-again {
-    margin-top: var(--perfect-fourth-4);
-    margin-bottom: var(--perfect-fourth-4);
-  }
-  .failure {
-    filter: hue-rotate(207deg);
-  }
-  .failure > * {
-    filter: hue-rotate(-207deg);
   }
   :global(.dmd-task-page-wrap .notification-bar) {
     width: 30rem;

--- a/services/admin/static/style.css
+++ b/services/admin/static/style.css
@@ -155,6 +155,21 @@ Source: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_visually-hidden
   grid-gap: var(--auto-grid-gap);
 }
 
+/* Commonly used grids */
+.grid {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+.grid__col_2 {
+  grid-template-areas: "a a";
+}
+
+.grid__col_3 {
+  grid-template-areas: "a a a";
+}
+
 /* Flexbox alignment */
 .auto-align {
   display: inline-flex;

--- a/services/admin/static/style.css
+++ b/services/admin/static/style.css
@@ -39,6 +39,8 @@
   --border-color: #ccc;
   /* Change this to set the font colour for the app */
   --base-font-color: var(--dark-font);
+  /* Change this to set the bg color for items of high contrast*/
+  --darkest-bg: #222;
   /* Change this to set the interactive element colors, ex: alert, buttons */
   /* Primary */
   --primary: var(--teal);
@@ -514,12 +516,17 @@ table {
   text-align: left;
   border-collapse: collapse;
   border-spacing: 0;
-  border-radius: var(--border-radius);
+  /*border-radius: var(--border-radius);
+  border: solid var(--border-color) 1px;*/
 }
 
 caption {
   text-align: left;
   padding: 1rem;
+}
+
+thead {
+  background: var(--backdrop-bg);
 }
 
 tbody {
@@ -530,8 +537,14 @@ tbody tr.clickable:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
+/*
+tr:nth-child(even) {
+  background-color: rgba(0, 0, 0, 0.02);
+}*/
+
 thead th {
   padding: 1rem;
+  font-weight: bold;
 }
 
 th {

--- a/services/admin/static/style.css
+++ b/services/admin/static/style.css
@@ -398,6 +398,11 @@ button,
   cursor: pointer;
 }
 
+button.sm,
+.button.sm {
+  padding: var(--perfect-fourth-8) var(--perfect-fourth-6);
+}
+
 button.lg,
 .button.lg {
   padding: var(--perfect-fourth-7) var(--perfect-fourth-3);
@@ -775,4 +780,14 @@ fieldset {
   100% {
     opacity: 0.5;
   }
+}
+
+/* To be used surrounding code like the JsonTree*/
+.code-block {
+  border: 1px solid var(--border-color);
+  padding: var(--perfect-fourth-6) var(--perfect-fourth-8);
+  margin: var(--margin-sm);
+  white-space: pre-line;
+  border-radius: var(--border-radius);
+  background-color: var(--base-bg);
 }


### PR DESCRIPTION
## 4. Split operation success

### Interface: `/dmd/task/$uuid`

Congrats! The metadata file was valid. Results of the split operation are in the `items` array. Not every item will itself be valid. 
- [ ] First show the interface where a prefix can be specified for a "Look up in Access Platform" button that calls `slug.resolveMany` with each id prepended by the prefix if it's there. **Question**: do we want to do a separate lookup for preservation, or do we also want to do the preservation lookup when we do this one? Separating the two lookups might be an alternative to the `[ ] Access [ ] Preservation` checkboxes below. **Question**: what are we using to do the preservation lookup? `dipstaging`? Note - only pass in valid items
- [ ] List split items in a table, maintaining the order of every item is something we'll want to keep throughout. This sets up a grid that should show every possible thing that will be updated by this DMD task.  For each item, show a row with the following columns:
  - id (from the item's `id` field)
  - label (from the item's `label` field)
  - valid: 
     - For valid items, a preview button that opens up a modal containing the results of `dmdtask.fetchResult` with type `json`. May elaborate on this later as we get feedback.
     - For invalid items, the error found in `splitResult.message`. Nothing further can be done with them.
  - access: blank before slugs are looked up; shows the result of the lookup for this id
  - preservation: same but with the preservation lookup result
- [ ] Show, somewhere, `Access, Preservation` checkboxes that determine where updates can go. At least one must be selected for updates to run. (? - **Enhancement**: Add an `Update` checkbox to each lookup result. Each is selected by default.) 
- [ ] For now, everything that is updatable will be updated when a big `Update Descriptive Metadata Records` button is pressed.
- [ ] We'll also want to provide a link back to `/dmd/new` if the results of the split aren't going to be processed further.
- [ ] When the update is triggered, the front-end will marshal a series of `dmdtask.storeAccess` and `dmdtask.storePreservation` requests corresponding to the successful lookups. A progress indicator of some kind should display. The user shouldn't be able to mess with anything else.
- [ ] Once the update is complete, maybe show something that says it's done. 
- [ ] The user can repeat updates whenever they like.