### PR TITLE
DMD task: Step 1-3 Lapin routes

### DIFF
--- a/packages/data/src/dmd/index.ts
+++ b/packages/data/src/dmd/index.ts
@@ -1,8 +1,26 @@
-export {
+import {
   DMDTask,
   WaitingDMDTask,
   FailedDMDTask,
   SucceededDMDTask,
 } from "./Task.js";
 
+export const isWaitingDMDTask = (obj: DMDTask): obj is WaitingDMDTask => {
+  return WaitingDMDTask.safeParse(obj).success;
+};
+
+export const isFailedDMDTask = (obj: DMDTask): obj is FailedDMDTask => {
+  return FailedDMDTask.safeParse(obj).success;
+};
+
+export const isSucceededDMDTask = (obj: DMDTask): obj is SucceededDMDTask => {
+  return SucceededDMDTask.safeParse(obj).success;
+};
+
+export {
+  DMDTask,
+  WaitingDMDTask,
+  FailedDMDTask,
+  SucceededDMDTask,
+} from "./Task.js";
 export { DMDFORMATS, DMDFormat, DMDOUTPUTS, DMDOutput } from "./types.js";

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -29,6 +29,9 @@ export {
   WaitingDMDTask,
   FailedDMDTask,
   SucceededDMDTask,
+  isWaitingDMDTask,
+  isFailedDMDTask,
+  isSucceededDMDTask,
 } from "./dmd/index.js";
 
 export {

--- a/packages/lapin-router/src/router.ts
+++ b/packages/lapin-router/src/router.ts
@@ -6,6 +6,7 @@ import { accessObjectRouter } from "./routes/accessObject.js";
 import { collectionRouter } from "./routes/collection.js";
 import { manifestRouter } from "./routes/manifest.js";
 import { slugRouter } from "./routes/slug.js";
+import { dmdTaskRouter } from "./routes/dmdTask.js";
 
 /**
  * Converts an HTTP Error (i.e. one with `status` as its 3-digit code) to
@@ -32,6 +33,7 @@ export const router = createRouter()
   .merge("slug.", slugRouter)
   .merge("accessObject.", accessObjectRouter)
   .merge("manifest.", manifestRouter)
-  .merge("collection.", collectionRouter);
+  .merge("collection.", collectionRouter)
+  .merge("dmdTask.", dmdTaskRouter);
 
 export type LapinRouter = typeof router;

--- a/packages/lapin-router/src/routes/dmdTask.ts
+++ b/packages/lapin-router/src/routes/dmdTask.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-import { MDTYPES, User, Slug } from "@crkn-rcdr/access-data";
+import { DMDFORMATS, User, Slug } from "@crkn-rcdr/access-data";
 import { TRPCError } from "@trpc/server";
 import { createRouter, httpErrorToTRPC } from "../router.js";
 
 const NewInput = z.object({
   user: User,
-  mdType: z.enum(MDTYPES),
+  format: z.enum(DMDFORMATS),
   file: z.string(), // any othervalidation needed?
 });
 

--- a/packages/lapin-router/src/routes/dmdTask.ts
+++ b/packages/lapin-router/src/routes/dmdTask.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { MDTYPES, User, Slug } from "@crkn-rcdr/access-data";
+import { TRPCError } from "@trpc/server";
+import { createRouter, httpErrorToTRPC } from "../router.js";
+
+const NewInput = z.object({
+  user: User,
+  mdType: z.enum(MDTYPES), //"csvissueinfo" | "csvdc" | "marc490" | "marcoocihm" | "marcooe";
+  file: z.string(), // any othervalidation needed?
+});
+
+export const dmdTaskRouter = createRouter()
+  .query("get", {
+    input: Slug.parse,
+    async resolve({ input: id, ctx }) {
+      const response = await ctx.couch.dmdtask.getSafe(id);
+      if (response.found) return response.doc;
+      throw new TRPCError({
+        code: "PATH_NOT_FOUND",
+        message: `No dmd task with id ${id} found.`,
+      });
+    },
+  })
+  .mutation("create", {
+    input: NewInput.parse,
+    async resolve({ input, ctx }) {
+      try {
+        return await ctx.couch.dmdtask.create(input);
+      } catch (e) {
+        throw httpErrorToTRPC(e);
+      }
+    },
+  });

--- a/packages/lapin-router/src/routes/dmdTask.ts
+++ b/packages/lapin-router/src/routes/dmdTask.ts
@@ -5,7 +5,7 @@ import { createRouter, httpErrorToTRPC } from "../router.js";
 
 const NewInput = z.object({
   user: User,
-  mdType: z.enum(MDTYPES), //"csvissueinfo" | "csvdc" | "marc490" | "marcoocihm" | "marcooe";
+  mdType: z.enum(MDTYPES),
   file: z.string(), // any othervalidation needed?
 });
 

--- a/services/admin/src/lib/components/dmd/DmdNewTaskForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdNewTaskForm.svelte
@@ -35,9 +35,9 @@ none
     | "marcooe";
 
   /**
-   * @type {string | undefined} This is the base 64 encoded string for the metadata file that will be stored in the couch attachment.
+   * @type {string} This is the base 64 encoded string for the metadata file that will be stored in the couch attachment.
    */
-  let b64EncodedMetadataFileText: string | undefined = undefined;
+  let b64EncodedMetadataFileText: string;
 
   /**
    * @type {string } Thiis variable is used to show any error with the user's selections to them.
@@ -75,12 +75,10 @@ none
             mdType: metadataType,
             file: b64EncodedMetadataFileText,
           };
-          console.log(bodyObj);
           const response = await $session.lapin.mutation(
             `dmdTask.create`,
             bodyObj
           );
-          console.log("response", response);
           if (response) {
             goto(`/dmd/${response}`);
             return {

--- a/services/admin/src/lib/components/dmd/DmdNewTaskForm.svelte
+++ b/services/admin/src/lib/components/dmd/DmdNewTaskForm.svelte
@@ -72,7 +72,7 @@ none
         try {
           const bodyObj = {
             user: $session.user,
-            mdType: metadataType,
+            format: metadataType,
             file: b64EncodedMetadataFileText,
           };
           const response = await $session.lapin.mutation(

--- a/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
@@ -6,7 +6,7 @@ Displays a dmd task in an error state.
 ### Properties
 |    |    |    |
 | -- | -- | -- |
-| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
+| dmdTask: FailedDMDTask | required | The dmd task to be displayed. |
 | message: string | required | The message to be displayed in the error notification bar. |
 
 ### Usage
@@ -18,27 +18,19 @@ Displays a dmd task in an error state.
 ```
 -->
 <script lang="ts">
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
+  import type { FailedDMDTask } from "@crkn-rcdr/access-data";
   import DmdTaskTimeInfoTable from "$lib/components/dmd/DmdTaskTimeInfoTable.svelte";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
 
   /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
+   * @type {FailedDMDTask} The dmdtask being displayed.
    */
-  export let dmdTask:
-    | WaitingDMDTask
-    | FailedDMDTask
-    | SucceededDMDTask
-    | undefined;
+  export let dmdTask: FailedDMDTask;
 
   /**
    * @type {string} The message to be displayed in the error notification bar.
    */
-  export let message: string | undefined;
+  export let message: string;
 </script>
 
 <div class="hero hero__gradient full-page failure">

--- a/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitFailureViewer.svelte
@@ -6,7 +6,7 @@ Displays a dmd task in an error state.
 ### Properties
 |    |    |    |
 | -- | -- | -- |
-| dmdTask: FailedDMDTask | required | The dmd task to be displayed. |
+| dmdTask: FailedDMDTask or undefined | optional | The dmd task to be displayed. |
 | message: string | required | The message to be displayed in the error notification bar. |
 
 ### Usage
@@ -23,9 +23,9 @@ Displays a dmd task in an error state.
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
 
   /**
-   * @type {FailedDMDTask} The dmdtask being displayed.
+   * @type {FailedDMDTask | undefined} The dmdtask being displayed.
    */
-  export let dmdTask: FailedDMDTask;
+  export let dmdTask: FailedDMDTask | undefined = undefined;
 
   /**
    * @type {string} The message to be displayed in the error notification bar.

--- a/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
+++ b/services/admin/src/lib/components/dmd/DmdSplitWaitingViewer.svelte
@@ -6,7 +6,7 @@ Displays a dmd task in an waiting state.
 ### Properties
 |    |    |    |
 | -- | -- | -- |
-| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
+| dmdTask: WaitingDMDTask | required | The dmd task to be displayed. |
 
 ### Usage
 ```
@@ -14,22 +14,14 @@ Displays a dmd task in an waiting state.
 ```
 -->
 <script lang="ts">
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
+  import type { WaitingDMDTask } from "@crkn-rcdr/access-data";
   import DmdTaskTimeInfoTable from "$lib/components/dmd/DmdTaskTimeInfoTable.svelte";
   import Loading from "$lib/components/shared/Loading.svelte";
 
   /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
+   * @type {WaitingDMDTask} The dmdtask being displayed.
    */
-  export let dmdTask:
-    | WaitingDMDTask
-    | FailedDMDTask
-    | SucceededDMDTask
-    | undefined;
+  export let dmdTask: WaitingDMDTask;
 </script>
 
 <div class="hero hero__gradient full-page">

--- a/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
@@ -22,17 +22,17 @@ Displays a dmd task's time based information in a table, the user sees the task 
 </script>
 
 <div class="dmd-request-info">
-  {#if dmdTask?.["updated"]}
+  {#if dmdTask?.updated}
     <span>Request inititated:</span>
     <span>
-      {`${new Date(parseInt(`${dmdTask["updated"]}`) * 1000).toLocaleString()}`}
+      {`${new Date(parseInt(`${dmdTask.updated}`) * 1000).toLocaleString()}`}
     </span>
   {/if}
-  {#if dmdTask?.["process"]?.["requestDate"]}
+  {#if dmdTask?.process?.["requestDate"]}
     <span>Request updated:</span>
     <span>
       {`${new Date(
-        parseInt(`${dmdTask["process"]["requestDate"]}`) * 1000
+        parseInt(`${dmdTask.process["requestDate"]}`) * 1000
       ).toLocaleString()}`}
     </span>
   {/if}

--- a/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
+++ b/services/admin/src/lib/components/dmd/DmdTaskTimeInfoTable.svelte
@@ -6,7 +6,7 @@ Displays a dmd task's time based information in a table, the user sees the task 
 ### Properties
 |    |    |    |
 | -- | -- | -- |
-| dmdTask: WaitingDMDTask or FailedDMDTask or SucceededDMDTask  | required | The dmd task to be displayed. |
+| dmdTask: DMDTask | required | The dmd task to be displayed. |
 
 ### Usage
 ```
@@ -14,26 +14,28 @@ Displays a dmd task's time based information in a table, the user sees the task 
 ```
 -->
 <script lang="ts">
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
-  } from "@crkn-rcdr/access-data";
+  import type { DMDTask } from "@crkn-rcdr/access-data";
   /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask | undefined} The dmdtask being displayed.
+   * @type {DMDTask} The dmdtask being displayed.
    */
-  export let dmdTask:
-    | WaitingDMDTask
-    | FailedDMDTask
-    | SucceededDMDTask
-    | undefined;
+  export let dmdTask: DMDTask;
 </script>
 
 <div class="dmd-request-info">
-  <span>Request inititated:</span>
-  <span>{dmdTask?.["updated"]}</span>
-  <span>Request updated:</span>
-  <span>{dmdTask?.["process"]?.["requestDate"]}</span>
+  {#if dmdTask?.["updated"]}
+    <span>Request inititated:</span>
+    <span>
+      {`${new Date(parseInt(`${dmdTask["updated"]}`) * 1000).toLocaleString()}`}
+    </span>
+  {/if}
+  {#if dmdTask?.["process"]?.["requestDate"]}
+    <span>Request updated:</span>
+    <span>
+      {`${new Date(
+        parseInt(`${dmdTask["process"]["requestDate"]}`) * 1000
+      ).toLocaleString()}`}
+    </span>
+  {/if}
 </div>
 
 <style>

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -7,7 +7,7 @@
   import type { RootLoadOutput } from "$lib/types";
   export const load: Load<RootLoadOutput> = async ({ page, context }) => {
     try {
-      if (page.params["taskId"]) {
+      if (page?.params?.["taskId"]) {
         const response = await context.lapin.query(
           "dmdTask.get",
           page.params["taskId"]
@@ -70,15 +70,15 @@
 <div class="dmd-task-page-wrap">
   {#if !dmdTask}
     Loading...
-  {:else if !dmdTask?.["process"] || !("succeeded" in dmdTask?.["process"])}
-    <DmdSplitWaitingViewer dmdTask={getAsWaitingTask()} />
-  {:else if !dmdTask?.["process"]?.["succeeded"]}
+  {:else if SucceededDMDTask.safeParse(dmdTask).success}
+    <DmdSplitSuccessStoreForm /> <!--dmdTask={getAsSucceededTask()} -->
+  {:else if FailedDMDTask.safeParse(dmdTask).success}
     <DmdSplitFailureViewer
       dmdTask={getAsFailedTask()}
       message={dmdTask?.["process"]?.["message"]}
     />
-  {:else if dmdTask?.["items"]?.length}
-    <DmdSplitSuccessStoreForm /> <!--dmdTask={getAsSucceededTask()} -->
+  {:else if WaitingDMDTask.safeParse(dmdTask).success}
+    <DmdSplitWaitingViewer dmdTask={getAsWaitingTask()} />
   {:else}
     <!--JUST In Case All Else Fails-->
     <DmdSplitFailureViewer

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -32,6 +32,9 @@
     FailedDMDTask,
     SucceededDMDTask,
     DMDTask,
+    isWaitingDMDTask,
+    isFailedDMDTask,
+    isSucceededDMDTask,
   } from "@crkn-rcdr/access-data";
   import DmdSplitWaitingViewer from "$lib/components/dmd/DmdSplitWaitingViewer.svelte";
   import DmdSplitFailureViewer from "$lib/components/dmd/DmdSplitFailureViewer.svelte";
@@ -41,44 +44,17 @@
    * @type {DMDTask} The dmdtask being displayed by the page.
    */
   export let dmdTask: DMDTask; //WaitingDMDTask | FailedDMDTask | SucceededDMDTask;
-
-  /**
-   * Casts @var dmdTask to type WaitingDMDTask for use in components that expect a WaitingDMDTask
-   * @returns void
-   */
-  function getAsWaitingTask(): WaitingDMDTask {
-    return <WaitingDMDTask>dmdTask;
-  }
-
-  /**
-   * Casts @var dmdTask to type FailedDMDTask for use in components that expect a FailedDMDTask
-   * @returns void
-   */
-  function getAsFailedTask(): FailedDMDTask {
-    return <FailedDMDTask>dmdTask;
-  }
-
-  /**
-   * Casts @var dmdTask to type SucceededDMDTask for use in components that expect a SucceededDMDTask
-   * @returns void
-   */
-  function getAsSucceededTask(): SucceededDMDTask {
-    return <SucceededDMDTask>dmdTask;
-  }
 </script>
 
 <div class="dmd-task-page-wrap">
   {#if !dmdTask}
     Loading...
-  {:else if SucceededDMDTask.safeParse(dmdTask).success}
+  {:else if isSucceededDMDTask(dmdTask)}
     <DmdSplitSuccessStoreForm /> <!--dmdTask={getAsSucceededTask()} -->
-  {:else if FailedDMDTask.safeParse(dmdTask).success}
-    <DmdSplitFailureViewer
-      dmdTask={getAsFailedTask()}
-      message={dmdTask.process["message"]}
-    />
-  {:else if WaitingDMDTask.safeParse(dmdTask).success}
-    <DmdSplitWaitingViewer dmdTask={getAsWaitingTask()} />
+  {:else if isFailedDMDTask(dmdTask)}
+    <DmdSplitFailureViewer {dmdTask} message={dmdTask.process["message"]} />
+  {:else if isWaitingDMDTask(dmdTask)}
+    <DmdSplitWaitingViewer {dmdTask} />
   {:else}
     <!--JUST In Case All Else Fails-->
     <DmdSplitFailureViewer

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -75,14 +75,13 @@
   {:else if FailedDMDTask.safeParse(dmdTask).success}
     <DmdSplitFailureViewer
       dmdTask={getAsFailedTask()}
-      message={dmdTask?.["process"]?.["message"]}
+      message={dmdTask.process["message"]}
     />
   {:else if WaitingDMDTask.safeParse(dmdTask).success}
     <DmdSplitWaitingViewer dmdTask={getAsWaitingTask()} />
   {:else}
     <!--JUST In Case All Else Fails-->
     <DmdSplitFailureViewer
-      dmdTask={getAsFailedTask()}
       message="No objects were split from the metadata file."
     />
   {/if}

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -27,12 +27,10 @@
    * @file
    * @description This page displays the various states of and information about a dmdtask
    */
-  //import { getStores } from "$app/stores";
-  //import type { Session } from "$lib/types";
   import {
-    //WaitingDMDTask,
-    //FailedDMDTask,
-    //SucceededDMDTask,
+    WaitingDMDTask,
+    FailedDMDTask,
+    SucceededDMDTask,
     DMDTask,
   } from "@crkn-rcdr/access-data";
   import DmdSplitWaitingViewer from "$lib/components/dmd/DmdSplitWaitingViewer.svelte";
@@ -45,44 +43,46 @@
   export let dmdTask: DMDTask; //WaitingDMDTask | FailedDMDTask | SucceededDMDTask;
 
   /**
-   * @type {Session} The session store that contains the module for sending requests to lapin.
+   * Casts @var dmdTask to type WaitingDMDTask for use in components that expect a WaitingDMDTask
+   * @returns void
    */
-  //const { session } = getStores<Session>();
+  function getAsWaitingTask(): WaitingDMDTask {
+    return <WaitingDMDTask>dmdTask;
+  }
 
-  /* TODO: Later grab from backend. */
-  /* = {
-    id: "123",
-    updated: "1628785112",
-    attachments: {
-      // ...metadata file info
-    },
-    user: $session.user, //for now
-    mdType: "marcooe",
-    process: {
-      requestDate: "1628785101",
-      //succeeded: false,
-      //message: "The process.message from the backend",
-    },
-    //items: [{}],
-  };*/
+  /**
+   * Casts @var dmdTask to type FailedDMDTask for use in components that expect a FailedDMDTask
+   * @returns void
+   */
+  function getAsFailedTask(): FailedDMDTask {
+    return <FailedDMDTask>dmdTask;
+  }
+
+  /**
+   * Casts @var dmdTask to type SucceededDMDTask for use in components that expect a SucceededDMDTask
+   * @returns void
+   */
+  function getAsSucceededTask(): SucceededDMDTask {
+    return <SucceededDMDTask>dmdTask;
+  }
 </script>
 
 <div class="dmd-task-page-wrap">
   {#if !dmdTask}
     Loading...
   {:else if !dmdTask?.["process"] || !("succeeded" in dmdTask?.["process"])}
-    <DmdSplitWaitingViewer {dmdTask} />
+    <DmdSplitWaitingViewer dmdTask={getAsWaitingTask()} />
   {:else if !dmdTask?.["process"]?.["succeeded"]}
     <DmdSplitFailureViewer
-      {dmdTask}
+      dmdTask={getAsFailedTask()}
       message={dmdTask?.["process"]?.["message"]}
     />
   {:else if dmdTask?.["items"]?.length}
-    <DmdSplitSuccessStoreForm />
+    <DmdSplitSuccessStoreForm /> <!--dmdTask={getAsSucceededTask()} -->
   {:else}
     <!--JUUUST In Case-->
     <DmdSplitFailureViewer
-      {dmdTask}
+      dmdTask={getAsFailedTask()}
       message="No objects were split from the metadata file."
     />
   {/if}

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -80,7 +80,7 @@
   {:else if dmdTask?.["items"]?.length}
     <DmdSplitSuccessStoreForm /> <!--dmdTask={getAsSucceededTask()} -->
   {:else}
-    <!--JUUUST In Case-->
+    <!--JUST In Case All Else Fails-->
     <DmdSplitFailureViewer
       dmdTask={getAsFailedTask()}
       message="No objects were split from the metadata file."

--- a/services/admin/src/routes/dmd/[taskId]/index.svelte
+++ b/services/admin/src/routes/dmd/[taskId]/index.svelte
@@ -3,6 +3,23 @@
    * @module
    * @description loads in the dmdtask from the backend using the params in the route of the page
    */
+  import type { Load } from "@sveltejs/kit";
+  import type { RootLoadOutput } from "$lib/types";
+  export const load: Load<RootLoadOutput> = async ({ page, context }) => {
+    try {
+      if (page.params["taskId"]) {
+        const response = await context.lapin.query(
+          "dmdTask.get",
+          page.params["taskId"]
+        );
+        const dmdTask = DMDTask.parse(response);
+        return { props: { dmdTask } };
+      }
+      return { props: {} };
+    } catch (e) {
+      return e;
+    }
+  };
 </script>
 
 <script lang="ts">
@@ -10,27 +27,30 @@
    * @file
    * @description This page displays the various states of and information about a dmdtask
    */
-  import { getStores } from "$app/stores";
-  import type { Session } from "$lib/types";
-  import type {
-    WaitingDMDTask,
-    FailedDMDTask,
-    SucceededDMDTask,
+  //import { getStores } from "$app/stores";
+  //import type { Session } from "$lib/types";
+  import {
+    //WaitingDMDTask,
+    //FailedDMDTask,
+    //SucceededDMDTask,
+    DMDTask,
   } from "@crkn-rcdr/access-data";
   import DmdSplitWaitingViewer from "$lib/components/dmd/DmdSplitWaitingViewer.svelte";
   import DmdSplitFailureViewer from "$lib/components/dmd/DmdSplitFailureViewer.svelte";
   import DmdSplitSuccessStoreForm from "$lib/components/dmd/DmdSplitSuccessStoreForm.svelte";
 
   /**
+   * @type {DMDTask} The dmdtask being displayed by the page.
+   */
+  export let dmdTask: DMDTask; //WaitingDMDTask | FailedDMDTask | SucceededDMDTask;
+
+  /**
    * @type {Session} The session store that contains the module for sending requests to lapin.
    */
-  const { session } = getStores<Session>();
+  //const { session } = getStores<Session>();
 
   /* TODO: Later grab from backend. */
-  /**
-   * @type {WaitingDMDTask | FailedDMDTask | SucceededDMDTask} The dmdtask being displayed by the page.
-   */
-  const dmdTask: WaitingDMDTask | FailedDMDTask | SucceededDMDTask = {
+  /* = {
     id: "123",
     updated: "1628785112",
     attachments: {
@@ -44,11 +64,13 @@
       //message: "The process.message from the backend",
     },
     //items: [{}],
-  };
+  };*/
 </script>
 
 <div class="dmd-task-page-wrap">
-  {#if !("succeeded" in dmdTask?.["process"])}
+  {#if !dmdTask}
+    Loading...
+  {:else if !dmdTask?.["process"] || !("succeeded" in dmdTask?.["process"])}
     <DmdSplitWaitingViewer {dmdTask} />
   {:else if !dmdTask?.["process"]?.["succeeded"]}
     <DmdSplitFailureViewer


### PR DESCRIPTION
### Lapin route: `dmdTask.new`

Input:

```ts
type NewInput = {
  user: User;
  mdType: "csvissueinfo" | "csvdc" | "marc490" | "marcoocihm" | "marcooe";
  file: string;
};
```

Creates a new `dmdtask` document, through a couch-utils method, with an auto-generated uuid, the dmdType, and the file inserted as an attachment. Theoretically, since it's already base64-encoded, the `_attachments` object can be built in the initial request. Will have to research this a little bit. Decoding the string and then uploading it the standard way can work as an alternative.

- [x] Done

### Lapin route: `dmdTask.get`

Grabs the dmd task by id from the database

- [x] Done
