### PR TITLE
Test data for Cantaloupe handling the `extension` field for canvases.

### DIFF
--- a/services/couchdb/access/fixtures/69429_m0bz6154gh7n.json
+++ b/services/couchdb/access/fixtures/69429_m0bz6154gh7n.json
@@ -1,0 +1,66 @@
+{
+  "_id": "69429/m0bz6154gh7n",
+  "type": "manifest",
+  "updateInternalmeta": {
+    "requestDate": 1630639028.569,
+    "processDate": 1630639032.311,
+    "succeeded": true,
+    "message": ""
+  },
+  "dmdType": "marc",
+  "ocrPdf": {
+    "size": 1099206,
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.pdf"
+  },
+  "label": {
+    "none": "Hudson's Bay Company to Lord Clarendon : Hudson's Bay House, February 28th, 1854."
+  },
+  "public": "2020-08-29T16:27:09Z",
+  "canvases": [
+    {
+      "label": {
+        "none": "technical data sheet"
+      },
+      "id": "69429/c06d5pb4d58z"
+    },
+    {
+      "label": {
+        "none": "blank page"
+      },
+      "id": "69429/c02r3nx9kj8p"
+    },
+    {
+      "id": "69429/c0z02z51z77x",
+      "label": {
+        "none": "p. 1"
+      }
+    },
+    {
+      "label": {
+        "none": "p. 2"
+      },
+      "id": "69429/c0t727c49g60"
+    },
+    {
+      "label": {
+        "none": "p. 3"
+      },
+      "id": "69429/c0pg1hk6nq31"
+    },
+    {
+      "id": "69429/c0jq0ss90z39",
+      "label": {
+        "none": "p. 4"
+      }
+    },
+    {
+      "id": "69429/c0dz0311c62f",
+      "label": {
+        "none": "blank page"
+      }
+    }
+  ],
+  "from": "canvases",
+  "slug": "oocihm.45116",
+  "updated": 1630639028.569
+}

--- a/services/couchdb/canvas/design/access/views/copycanvasimage.js
+++ b/services/couchdb/canvas/design/access/views/copycanvasimage.js
@@ -1,0 +1,8 @@
+module.exports = {
+  map: function (doc) {
+    if ("master" in doc && "path" in doc.master) {
+      emit(null, null);
+    }
+  },
+  reduce: "_count",
+};

--- a/services/couchdb/canvas/fixtures/69429_c02r3nx9kj8p.json
+++ b/services/couchdb/canvas/fixtures/69429_c02r3nx9kj8p.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c02r3nx9kj8p",
+  "master": {
+    "height": 3645,
+    "width": 2226,
+    "mime": "image/tiff",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0002.tif",
+    "size": 7195
+  },
+  "ocrType": "txtmap",
+  "source": {
+    "from": "cihm",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0002.tif"
+  }
+}

--- a/services/couchdb/canvas/fixtures/69429_c02r3nx9kj8p.json
+++ b/services/couchdb/canvas/fixtures/69429_c02r3nx9kj8p.json
@@ -4,7 +4,7 @@
     "height": 3645,
     "width": 2226,
     "mime": "image/tiff",
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0002.tif",
+    "extension": "tif",
     "size": 7195
   },
   "ocrType": "txtmap",

--- a/services/couchdb/canvas/fixtures/69429_c06d5pb4d58z.json
+++ b/services/couchdb/canvas/fixtures/69429_c06d5pb4d58z.json
@@ -6,7 +6,7 @@
   },
   "master": {
     "size": 790367,
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0001.tif",
+    "extension": "tif",
     "mime": "image/tiff",
     "width": 3131,
     "height": 3971

--- a/services/couchdb/canvas/fixtures/69429_c06d5pb4d58z.json
+++ b/services/couchdb/canvas/fixtures/69429_c06d5pb4d58z.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c06d5pb4d58z",
+  "source": {
+    "from": "cihm",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0001.tif"
+  },
+  "master": {
+    "size": 790367,
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0001.tif",
+    "mime": "image/tiff",
+    "width": 3131,
+    "height": 3971
+  },
+  "ocrType": "txtmap"
+}

--- a/services/couchdb/canvas/fixtures/69429_c0dz0311c62f.json
+++ b/services/couchdb/canvas/fixtures/69429_c0dz0311c62f.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c0dz0311c62f",
+  "source": {
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0007.tif",
+    "from": "cihm"
+  },
+  "ocrType": "txtmap",
+  "master": {
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0007.tif",
+    "size": 7537,
+    "height": 3590,
+    "mime": "image/tiff",
+    "width": 2099
+  }
+}

--- a/services/couchdb/canvas/fixtures/69429_c0dz0311c62f.json
+++ b/services/couchdb/canvas/fixtures/69429_c0dz0311c62f.json
@@ -6,7 +6,7 @@
   },
   "ocrType": "txtmap",
   "master": {
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0007.tif",
+    "extension": "tif",
     "size": 7537,
     "height": 3590,
     "mime": "image/tiff",

--- a/services/couchdb/canvas/fixtures/69429_c0jq0ss90z39.json
+++ b/services/couchdb/canvas/fixtures/69429_c0jq0ss90z39.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c0jq0ss90z39",
+  "source": {
+    "from": "cihm",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0006.tif"
+  },
+  "ocrType": "txtmap",
+  "master": {
+    "size": 62825,
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0006.tif",
+    "width": 2402,
+    "mime": "image/tiff",
+    "height": 3776
+  }
+}

--- a/services/couchdb/canvas/fixtures/69429_c0jq0ss90z39.json
+++ b/services/couchdb/canvas/fixtures/69429_c0jq0ss90z39.json
@@ -7,7 +7,7 @@
   "ocrType": "txtmap",
   "master": {
     "size": 62825,
-    "extension": "tif"
+    "extension": "tif",
     "width": 2402,
     "mime": "image/tiff",
     "height": 3776

--- a/services/couchdb/canvas/fixtures/69429_c0jq0ss90z39.json
+++ b/services/couchdb/canvas/fixtures/69429_c0jq0ss90z39.json
@@ -7,7 +7,7 @@
   "ocrType": "txtmap",
   "master": {
     "size": 62825,
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0006.tif",
+    "extension": "tif"
     "width": 2402,
     "mime": "image/tiff",
     "height": 3776

--- a/services/couchdb/canvas/fixtures/69429_c0pg1hk6nq31.json
+++ b/services/couchdb/canvas/fixtures/69429_c0pg1hk6nq31.json
@@ -2,7 +2,7 @@
   "_id": "69429/c0pg1hk6nq31",
   "master": {
     "size": 86733,
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0005.tif",
+    "extension": "tif",
     "width": 2258,
     "mime": "image/tiff",
     "height": 3674

--- a/services/couchdb/canvas/fixtures/69429_c0pg1hk6nq31.json
+++ b/services/couchdb/canvas/fixtures/69429_c0pg1hk6nq31.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c0pg1hk6nq31",
+  "master": {
+    "size": 86733,
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0005.tif",
+    "width": 2258,
+    "mime": "image/tiff",
+    "height": 3674
+  },
+  "ocrType": "txtmap",
+  "source": {
+    "from": "cihm",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0005.tif"
+  }
+}

--- a/services/couchdb/canvas/fixtures/69429_c0t727c49g60.json
+++ b/services/couchdb/canvas/fixtures/69429_c0t727c49g60.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c0t727c49g60",
+  "ocrType": "txtmap",
+  "master": {
+    "height": 3808,
+    "mime": "image/tiff",
+    "width": 2216,
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0004.tif",
+    "size": 83097
+  },
+  "source": {
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0004.tif",
+    "from": "cihm"
+  }
+}

--- a/services/couchdb/canvas/fixtures/69429_c0t727c49g60.json
+++ b/services/couchdb/canvas/fixtures/69429_c0t727c49g60.json
@@ -5,7 +5,7 @@
     "height": 3808,
     "mime": "image/tiff",
     "width": 2216,
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0004.tif",
+    "extension": "tif",
     "size": 83097
   },
   "source": {

--- a/services/couchdb/canvas/fixtures/69429_c0z02z51z77x.json
+++ b/services/couchdb/canvas/fixtures/69429_c0z02z51z77x.json
@@ -1,0 +1,15 @@
+{
+  "_id": "69429/c0z02z51z77x",
+  "master": {
+    "height": 3654,
+    "width": 2243,
+    "mime": "image/tiff",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0003.tif",
+    "size": 74135
+  },
+  "ocrType": "txtmap",
+  "source": {
+    "from": "cihm",
+    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0003.tif"
+  }
+}

--- a/services/couchdb/canvas/fixtures/69429_c0z02z51z77x.json
+++ b/services/couchdb/canvas/fixtures/69429_c0z02z51z77x.json
@@ -4,7 +4,7 @@
     "height": 3654,
     "width": 2243,
     "mime": "image/tiff",
-    "path": "oocihm.45116/data/sip/data/files/oocihm.45116.0003.tif",
+    "extension": "tif",
     "size": 74135
   },
   "ocrType": "txtmap",


### PR DESCRIPTION
See: https://github.com/crkn-rcdr/Access-Platform/issues/137
