### PR TITLE
Adding Collection Behaviour to the Editor

### DIFF
--- a/services/admin/src/lib/components/access-objects/InfoEditor.svelte
+++ b/services/admin/src/lib/components/access-objects/InfoEditor.svelte
@@ -81,17 +81,20 @@ This component displays the non content properties for an access editorObject an
         }}
       /><br /><br />
 
+      {#if isCollection(editorObject)}
+        <label for="behavior">Behavior</label><br />
+        <select
+          id="behavior"
+          name="behavior"
+          bind:value={editorObject["behavior"]}
+        >
+          <option>multi-part</option>
+          <option>unordered</option>
+        </select><br /><br />
+      {/if}
       <!--Fixtures don't have this yet, causes save to be enabled on load-->
 
       <!--span>
-    <label for="behavior">Behavior</label>
-    <select id="behavior" name="behavior" bind:value={manifest["behavior"]}>
-      <option>continuous</option>
-      <option>individuals</option>
-      <option>paged</option>
-      <option>unordered</option>
-    </select>
-  </span>
 
   <span>
     <label for="viewing-direction">Viewing Direction</label>

--- a/services/admin/src/lib/components/access-objects/InfoEditor.svelte
+++ b/services/admin/src/lib/components/access-objects/InfoEditor.svelte
@@ -82,7 +82,7 @@ This component displays the non content properties for an access editorObject an
       /><br /><br />
 
       {#if isCollection(editorObject)}
-        <label for="behavior">Behavior</label><br />
+        <label for="behavior">Behaviour</label><br />
         <select
           id="behavior"
           name="behavior"

--- a/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
@@ -170,10 +170,10 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
       </div>
       <div class="image-wrap">
         <img
-          alt={item.label?.none}
+          alt={item.data?.label?.none}
           class="thumbnail-img"
           src={`https://image-tor.canadiana.ca/iiif/2/${encodeURIComponent(
-            item.id
+            item.data?.id
           )}/full/!425,524/0/default.jpg`}
         />
       </div>

--- a/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
@@ -132,10 +132,9 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
   >
     <div
       class="thumbnail auto-align auto-align__full"
-      class:active={activeCanvasIndex === item.id}
-      class:new={item.new}
+      class:active={activeCanvasIndex === item.pos - 1}
       on:click={() => {
-        setActiveIndex(item.id);
+        setActiveIndex(item.pos - 1);
       }}
     >
       <div class="actions-wrap">
@@ -157,13 +156,13 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
               max={canvases.length}
               value={item.pos}
               on:changed={(e) => {
-                moveCanvas(e, item.id);
+                moveCanvas(e, item.pos - 1);
               }}
             />
           </div>
           <div
             class="action icon"
-            on:click={(e) => deleteCanvasByIndex(e, item.id)}
+            on:click={(e) => deleteCanvasByIndex(e, item.pos - 1)}
           >
             <TiTrash />
           </div>
@@ -171,10 +170,10 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
       </div>
       <div class="image-wrap">
         <img
-          alt={item.data?.label?.none}
+          alt={item.label?.none}
           class="thumbnail-img"
           src={`https://image-tor.canadiana.ca/iiif/2/${encodeURIComponent(
-            item.data?.id
+            item.id
           )}/full/!425,524/0/default.jpg`}
         />
       </div>

--- a/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
@@ -132,9 +132,10 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
   >
     <div
       class="thumbnail auto-align auto-align__full"
-      class:active={activeCanvasIndex === item.id - 1}
+      class:active={activeCanvasIndex === item.id}
+      class:new={item.new}
       on:click={() => {
-        setActiveIndex(item.id - 1);
+        setActiveIndex(item.id);
       }}
     >
       <div class="actions-wrap">
@@ -143,7 +144,7 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
           class:visibility-hidden={!showAddButton}
         >
           <div class="action pos">
-            {item.id}
+            {item.pos}
           </div>
           <div
             class="action pos-input"
@@ -154,15 +155,15 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
             <AutomaticResizeNumberInput
               name="position"
               max={canvases.length}
-              value={item.id}
+              value={item.pos}
               on:changed={(e) => {
-                moveCanvas(e, item.id - 1);
+                moveCanvas(e, item.id);
               }}
             />
           </div>
           <div
             class="action icon"
-            on:click={(e) => deleteCanvasByIndex(e, item.id - 1)}
+            on:click={(e) => deleteCanvasByIndex(e, item.id)}
           >
             <TiTrash />
           </div>

--- a/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
@@ -132,9 +132,9 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
   >
     <div
       class="thumbnail auto-align auto-align__full"
-      class:active={activeCanvasIndex === item.pos - 1}
+      class:active={activeCanvasIndex === item.id - 1}
       on:click={() => {
-        setActiveIndex(item.pos - 1);
+        setActiveIndex(item.id - 1);
       }}
     >
       <div class="actions-wrap">
@@ -143,7 +143,7 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
           class:visibility-hidden={!showAddButton}
         >
           <div class="action pos">
-            {item.pos}
+            {item.id}
           </div>
           <div
             class="action pos-input"
@@ -154,15 +154,15 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
             <AutomaticResizeNumberInput
               name="position"
               max={canvases.length}
-              value={item.pos}
+              value={item.id}
               on:changed={(e) => {
-                moveCanvas(e, item.pos - 1);
+                moveCanvas(e, item.id - 1);
               }}
             />
           </div>
           <div
             class="action icon"
-            on:click={(e) => deleteCanvasByIndex(e, item.pos - 1)}
+            on:click={(e) => deleteCanvasByIndex(e, item.id - 1)}
           >
             <TiTrash />
           </div>

--- a/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
@@ -227,8 +227,6 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
 
   .image-wrap {
     flex: 4;
-    text-align: right;
-    padding-right: 2rem;
   }
 
   .actions-wrap,

--- a/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
+++ b/services/admin/src/lib/components/canvases/CanvasThumbnailList.svelte
@@ -227,6 +227,8 @@ Displays a ribbon of canvases. The canvases can be re-ordered, and canvases can 
 
   .image-wrap {
     flex: 4;
+    text-align: right;
+    padding-right: 2rem;
   }
 
   .actions-wrap,

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -84,12 +84,18 @@ Allows the user to modify the member list for a collection.
     >
       <div
         class="members"
+<<<<<<< HEAD
         class:active={item?.id === activeMemberIndex}
         on:mousedown={() => setActiveIndex(item?.id)}
+=======
+        class:active={item.id - 1 === activeMemberIndex}
+        on:mousedown={() => setActiveIndex(item.id - 1)}
+>>>>>>> Fix typing of index model
       >
         <div class="auto-align">
           <div class="actions-wrap">
             <div class="auto-align auto-align__column">
+<<<<<<< HEAD
               {#if collection.behavior !== "unordered"}
                 <div class="action pos">
                   {item?.pos}
@@ -98,6 +104,23 @@ Allows the user to modify the member list for a collection.
                   class="action pos-input"
                   on:click={(e) => {
                     e.stopPropagation();
+=======
+              <div class="action pos">
+                {item.id}
+              </div>
+              <div
+                class="action pos-input"
+                on:click={(e) => {
+                  e.stopPropagation();
+                }}
+              >
+                <AutomaticResizeNumberInput
+                  name="position"
+                  max={collection?.members.length}
+                  value={item.id}
+                  on:changed={(e) => {
+                    moveMember(e, item.id - 1);
+>>>>>>> Fix typing of index model
                   }}
                 >
                   <AutomaticResizeNumberInput
@@ -112,7 +135,11 @@ Allows the user to modify the member list for a collection.
               {/if}
               <div
                 class="action icon"
+<<<<<<< HEAD
                 on:click={(e) => deleteMemberByIndex(e, item?.id)}
+=======
+                on:click={(e) => deleteCanvasByIndex(e, item.id - 1)}
+>>>>>>> Fix typing of index model
               >
                 <TiTrash />
               </div>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -89,24 +89,26 @@ Allows the user to modify the member list for a collection.
         <div class="auto-align">
           <div class="actions-wrap">
             <div class="auto-align auto-align__column">
-              <div class="action pos">
-                {item.pos}
-              </div>
-              <div
-                class="action pos-input"
-                on:click={(e) => {
-                  e.stopPropagation();
-                }}
-              >
-                <AutomaticResizeNumberInput
-                  name="position"
-                  max={collection?.members.length}
-                  value={item.pos}
-                  on:changed={(e) => {
-                    moveMember(e, item.pos - 1);
+              {#if collection.behavior !== "unordered"}
+                <div class="action pos">
+                  {item.pos}
+                </div>
+                <div
+                  class="action pos-input"
+                  on:click={(e) => {
+                    e.stopPropagation();
                   }}
-                />
-              </div>
+                >
+                  <AutomaticResizeNumberInput
+                    name="position"
+                    max={collection?.members.length}
+                    value={item.pos}
+                    on:changed={(e) => {
+                      moveMember(e, item.pos - 1);
+                    }}
+                  />
+                </div>
+              {/if}
               <div
                 class="action icon"
                 on:click={(e) => deleteCanvasByIndex(e, item.pos - 1)}

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -79,6 +79,7 @@ Allows the user to modify the member list for a collection.
     <VirtualList
       bind:dataList={collection.members}
       bind:activeIndex={activeMemberIndex}
+      draggable={collection.behavior !== "unordered"}
       let:item
     >
       <div

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -25,7 +25,10 @@ Allows the user to modify the member list for a collection.
   import CollectionMembersAddition from "./CollectionMembersAddition.svelte";
 
   export let collection: Collection;
+  export let showAddButton = true;
   let activeMemberIndex: number = 0;
+  let container: HTMLDivElement;
+
   const dispatch = createEventDispatcher();
 
   function setActiveIndex(index: number) {
@@ -34,6 +37,12 @@ Allows the user to modify the member list for a collection.
     if (index < 0) index = 0;
     activeMemberIndex = index;
     dispatch("membersClicked", { index });
+    collection.members = collection.members;
+  }
+
+  function jumpTo(index: number) {
+    let membersThumbnails = container.querySelectorAll(".thumbnail");
+    membersThumbnails?.[index]?.scrollIntoView();
   }
 
   function moveMember(event: any, originalItemIndex: number) {
@@ -48,7 +57,7 @@ Allows the user to modify the member list for a collection.
     // Highlight and move to new position
     activeMemberIndex = destinationItemIndex;
 
-    //jumpTo(activeMemberIndex);
+    jumpTo(activeMemberIndex);
     setActiveIndex(activeMemberIndex);
   }
 
@@ -67,7 +76,7 @@ Allows the user to modify the member list for a collection.
 </script>
 
 {#if collection}
-  <div>
+  <div class="auto-align auto-align__column">
     <CollectionMembersAddition
       bind:destinationMember={collection}
       on:done={() => {
@@ -79,12 +88,13 @@ Allows the user to modify the member list for a collection.
     <VirtualList
       bind:dataList={collection.members}
       bind:activeIndex={activeMemberIndex}
+      disabled={!showAddButton}
       let:item
     >
       <div
         class="members"
-        class:active={item.id === activeMemberIndex}
-        on:mousedown={() => setActiveIndex(item.id)}
+        class:active={item.pos - 1 === activeMemberIndex}
+        on:mousedown={() => setActiveIndex(item.pos - 1)}
       >
         <div class="auto-align">
           <div class="actions-wrap">
@@ -103,13 +113,13 @@ Allows the user to modify the member list for a collection.
                   max={collection?.members.length}
                   value={item.pos}
                   on:changed={(e) => {
-                    moveMember(e, item.id);
+                    moveMember(e, item.pos - 1);
                   }}
                 />
               </div>
               <div
                 class="action icon"
-                on:click={(e) => deleteCanvasByIndex(e, item.id)}
+                on:click={(e) => deleteCanvasByIndex(e, i)}
               >
                 <TiTrash />
               </div>
@@ -118,7 +128,7 @@ Allows the user to modify the member list for a collection.
           <div id="grid">
             <ul>
               <li>
-                <a href="/object/{item.data?.id}">{item.data?.id}</a>
+                <a href="/object/{item.id}">{item.id}</a>
               </li>
             </ul>
           </div>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -121,7 +121,7 @@ Allows the user to modify the member list for a collection.
           <div id="grid">
             <ul>
               <li>
-                <a href="/object/{item.id}">{item.id}</a>
+                <a href="/object/{item.data?.id}">{item.data?.id}</a>
               </li>
             </ul>
           </div>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -25,7 +25,6 @@ Allows the user to modify the member list for a collection.
   import CollectionMembersAddition from "./CollectionMembersAddition.svelte";
 
   export let collection: Collection;
-  export let showAddButton = true;
   let activeMemberIndex: number = 0;
   const dispatch = createEventDispatcher();
 
@@ -80,7 +79,6 @@ Allows the user to modify the member list for a collection.
     <VirtualList
       bind:dataList={collection.members}
       bind:activeIndex={activeMemberIndex}
-      disabled={!showAddButton}
       let:item
     >
       <div

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -84,29 +84,16 @@ Allows the user to modify the member list for a collection.
     >
       <div
         class="members"
-<<<<<<< HEAD
-        class:active={item?.id === activeMemberIndex}
-        on:mousedown={() => setActiveIndex(item?.id)}
-=======
         class:active={item.id - 1 === activeMemberIndex}
         on:mousedown={() => setActiveIndex(item.id - 1)}
->>>>>>> Fix typing of index model
+        class:active={item.id === activeMemberIndex}
+        on:mousedown={() => setActiveIndex(item.id)}
       >
         <div class="auto-align">
           <div class="actions-wrap">
             <div class="auto-align auto-align__column">
-<<<<<<< HEAD
-              {#if collection.behavior !== "unordered"}
-                <div class="action pos">
-                  {item?.pos}
-                </div>
-                <div
-                  class="action pos-input"
-                  on:click={(e) => {
-                    e.stopPropagation();
-=======
               <div class="action pos">
-                {item.id}
+                {item.pos}
               </div>
               <div
                 class="action pos-input"
@@ -117,10 +104,9 @@ Allows the user to modify the member list for a collection.
                 <AutomaticResizeNumberInput
                   name="position"
                   max={collection?.members.length}
-                  value={item.id}
+                  value={item.pos}
                   on:changed={(e) => {
                     moveMember(e, item.id - 1);
->>>>>>> Fix typing of index model
                   }}
                 >
                   <AutomaticResizeNumberInput
@@ -135,11 +121,7 @@ Allows the user to modify the member list for a collection.
               {/if}
               <div
                 class="action icon"
-<<<<<<< HEAD
-                on:click={(e) => deleteMemberByIndex(e, item?.id)}
-=======
                 on:click={(e) => deleteCanvasByIndex(e, item.id - 1)}
->>>>>>> Fix typing of index model
               >
                 <TiTrash />
               </div>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -1,8 +1,6 @@
 <!--
 @component
-
 TODO
-
 ### Overview
 Allows the user to modify the member list for a collection.
 ### Properties
@@ -23,11 +21,9 @@ Allows the user to modify the member list for a collection.
   import { moveArrayElement } from "$lib/utils/arrayUtil";
   import TiTrash from "svelte-icons/ti/TiTrash.svelte";
   import CollectionMembersAddition from "./CollectionMembersAddition.svelte";
-
   export let collection: Collection;
   let activeMemberIndex: number = 0;
   const dispatch = createEventDispatcher();
-
   function setActiveIndex(index: number) {
     if (index >= collection.members.length)
       index = collection.members.length - 1;
@@ -35,7 +31,6 @@ Allows the user to modify the member list for a collection.
     activeMemberIndex = index;
     dispatch("membersClicked", { index });
   }
-
   function moveMember(event: any, originalItemIndex: number) {
     // Move the member and trigger saving
     let destinationItemIndex = parseInt(event.detail.value) - 1;
@@ -47,11 +42,9 @@ Allows the user to modify the member list for a collection.
     collection.members = collection.members;
     // Highlight and move to new position
     activeMemberIndex = destinationItemIndex;
-
     //jumpTo(activeMemberIndex);
     setActiveIndex(activeMemberIndex);
   }
-
   function deleteMemberByIndex(event: any, index: number) {
     event.stopPropagation();
     if (index >= 0 && index < collection?.members.length) {
@@ -60,7 +53,6 @@ Allows the user to modify the member list for a collection.
       setActiveIndex(activeMemberIndex);
     }
   }
-
   onMount(() => {
     if (collection.members.length) activeMemberIndex = 0;
   });
@@ -75,7 +67,6 @@ Allows the user to modify the member list for a collection.
       }}
     />
     <br />
-
     <VirtualList
       bind:dataList={collection.members}
       bind:activeIndex={activeMemberIndex}
@@ -84,29 +75,20 @@ Allows the user to modify the member list for a collection.
     >
       <div
         class="members"
-        class:active={item.id - 1 === activeMemberIndex}
-        on:mousedown={() => setActiveIndex(item.id - 1)}
-        class:active={item.id === activeMemberIndex}
-        on:mousedown={() => setActiveIndex(item.id)}
+        class:active={item?.id === activeMemberIndex}
+        on:mousedown={() => setActiveIndex(item?.id)}
       >
         <div class="auto-align">
           <div class="actions-wrap">
             <div class="auto-align auto-align__column">
-              <div class="action pos">
-                {item.pos}
-              </div>
-              <div
-                class="action pos-input"
-                on:click={(e) => {
-                  e.stopPropagation();
-                }}
-              >
-                <AutomaticResizeNumberInput
-                  name="position"
-                  max={collection?.members.length}
-                  value={item.pos}
-                  on:changed={(e) => {
-                    moveMember(e, item.id - 1);
+              {#if collection.behavior !== "unordered"}
+                <div class="action pos">
+                  {item.pos}
+                </div>
+                <div
+                  class="action pos-input"
+                  on:click={(e) => {
+                    e.stopPropagation();
                   }}
                 >
                   <AutomaticResizeNumberInput
@@ -121,7 +103,7 @@ Allows the user to modify the member list for a collection.
               {/if}
               <div
                 class="action icon"
-                on:click={(e) => deleteCanvasByIndex(e, item.id - 1)}
+                on:click={(e) => deleteMemberByIndex(e, item.id)}
               >
                 <TiTrash />
               </div>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -27,8 +27,6 @@ Allows the user to modify the member list for a collection.
   export let collection: Collection;
   export let showAddButton = true;
   let activeMemberIndex: number = 0;
-  let container: HTMLDivElement;
-
   const dispatch = createEventDispatcher();
 
   function setActiveIndex(index: number) {
@@ -37,12 +35,6 @@ Allows the user to modify the member list for a collection.
     if (index < 0) index = 0;
     activeMemberIndex = index;
     dispatch("membersClicked", { index });
-    collection.members = collection.members;
-  }
-
-  function jumpTo(index: number) {
-    let membersThumbnails = container.querySelectorAll(".thumbnail");
-    membersThumbnails?.[index]?.scrollIntoView();
   }
 
   function moveMember(event: any, originalItemIndex: number) {
@@ -57,7 +49,7 @@ Allows the user to modify the member list for a collection.
     // Highlight and move to new position
     activeMemberIndex = destinationItemIndex;
 
-    jumpTo(activeMemberIndex);
+    //jumpTo(activeMemberIndex);
     setActiveIndex(activeMemberIndex);
   }
 
@@ -76,7 +68,7 @@ Allows the user to modify the member list for a collection.
 </script>
 
 {#if collection}
-  <div class="auto-align auto-align__column">
+  <div>
     <CollectionMembersAddition
       bind:destinationMember={collection}
       on:done={() => {
@@ -119,7 +111,7 @@ Allows the user to modify the member list for a collection.
               </div>
               <div
                 class="action icon"
-                on:click={(e) => deleteCanvasByIndex(e, i)}
+                on:click={(e) => deleteCanvasByIndex(e, item.pos - 1)}
               >
                 <TiTrash />
               </div>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -52,7 +52,7 @@ Allows the user to modify the member list for a collection.
     setActiveIndex(activeMemberIndex);
   }
 
-  function deleteCanvasByIndex(event: any, index: number) {
+  function deleteMemberByIndex(event: any, index: number) {
     event.stopPropagation();
     if (index >= 0 && index < collection?.members.length) {
       collection?.members.splice(index, 1);
@@ -84,15 +84,15 @@ Allows the user to modify the member list for a collection.
     >
       <div
         class="members"
-        class:active={item.pos - 1 === activeMemberIndex}
-        on:mousedown={() => setActiveIndex(item.pos - 1)}
+        class:active={item?.id === activeMemberIndex}
+        on:mousedown={() => setActiveIndex(item?.id)}
       >
         <div class="auto-align">
           <div class="actions-wrap">
             <div class="auto-align auto-align__column">
               {#if collection.behavior !== "unordered"}
                 <div class="action pos">
-                  {item.pos}
+                  {item?.pos}
                 </div>
                 <div
                   class="action pos-input"
@@ -103,16 +103,16 @@ Allows the user to modify the member list for a collection.
                   <AutomaticResizeNumberInput
                     name="position"
                     max={collection?.members.length}
-                    value={item.pos}
+                    value={item?.pos}
                     on:changed={(e) => {
-                      moveMember(e, item.pos - 1);
+                      moveMember(e, item?.id);
                     }}
                   />
                 </div>
               {/if}
               <div
                 class="action icon"
-                on:click={(e) => deleteCanvasByIndex(e, item.pos - 1)}
+                on:click={(e) => deleteMemberByIndex(e, item?.id)}
               >
                 <TiTrash />
               </div>
@@ -121,7 +121,7 @@ Allows the user to modify the member list for a collection.
           <div id="grid">
             <ul>
               <li>
-                <a href="/object/{item.data?.id}">{item.data?.id}</a>
+                <a href="/object/{item?.data?.id}">{item?.data?.id}</a>
               </li>
             </ul>
           </div>

--- a/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
+++ b/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
@@ -293,6 +293,7 @@ This component allows the user to search through other manifests and select canv
     width: 60px;
     display: flex;
     flex-direction: column;
+    z-index: 2;
   }
 
   .manifest-controls > * {
@@ -318,6 +319,7 @@ This component allows the user to search through other manifests and select canv
   .results {
     width: 100%;
     height: 100%;
+    overflow: hidden;
   }
 
   .results.full-page {
@@ -330,7 +332,7 @@ This component allows the user to search through other manifests and select canv
   }
 
   .canvas-list-item-viewer {
-    height: 100%;
+    height: 80vh;
     width: 100%;
     position: relative;
     background: var(--darkest-bg);
@@ -342,6 +344,8 @@ This component allows the user to search through other manifests and select canv
     padding: 0.7rem 5rem 0.7rem;
     color: var(--secondary-light);
     background-color: var(--dark-bg);
+    z-index: 1;
+    position: absolute;
   }
 
   /*.title > h6 {
@@ -353,6 +357,7 @@ This component allows the user to search through other manifests and select canv
 
   :global(.add-menu .referencestrip) {
     left: 60px !important;
+    top: 3rem;
   }
 
   :global(.openseadragon-canvas) {

--- a/services/admin/src/lib/components/manifests/ManifestContentEditor.svelte
+++ b/services/admin/src/lib/components/manifests/ManifestContentEditor.svelte
@@ -101,7 +101,7 @@ Allows the user to modify the canvas list for a manifest.
     message={typedChecks.manifest.getCanvasesValidationMsg(manifest.canvases)}
     status="fail"
   /-->
-  <div class="auto-align auto-align__full">
+  <div class="auto-align auto-align__full content-wrapper">
     <div class="list-wrapper">
       <!--button
         on:click={() => {
@@ -169,6 +169,10 @@ Allows the user to modify the canvas list for a manifest.
 {/if}
 
 <style>
+  .content-wrapper {
+    overflow: hidden;
+  }
+
   div {
     height: 100%;
   }

--- a/services/admin/src/lib/components/shared/SideMenuBody.svelte
+++ b/services/admin/src/lib/components/shared/SideMenuBody.svelte
@@ -27,5 +27,6 @@ None
   .side-menu-body {
     height: 100%;
     flex: 8.5;
+    background: var(--light-bg);
   }
 </style>

--- a/services/admin/src/lib/components/shared/SideMenuContainer.svelte
+++ b/services/admin/src/lib/components/shared/SideMenuContainer.svelte
@@ -237,15 +237,19 @@ A component that shows a navigable set of pages with a side menu to allow the us
   }
 
   .fixed-full-page {
-    position: fixed;
+    /*position: fixed;
     top: calc(6.5rem + var(--viewport-scaling));
     bottom: 0;
     right: 0;
     left: 0;
-    height: calc(100vh - 6.5rem - var(--viewport-scaling));
+    margin: auto;
+    max-width: 156rem;
+    */
+
+    height: calc(100vh - 7rem - var(--viewport-scaling));
   }
 
-  @media (max-width: 997px) {
+  /*@media (max-width: 997px) {
     .fixed-full-page {
       top: calc(9rem + var(--viewport-scaling));
       height: calc(100vh - 9rem - var(--viewport-scaling));
@@ -257,7 +261,7 @@ A component that shows a navigable set of pages with a side menu to allow the us
       top: calc(12rem + var(--viewport-scaling));
       height: calc(100vh - 12rem - var(--viewport-scaling));
     }
-  }
+  }*/
 
   .fixed-full-page .header {
     height: 12%;

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -55,12 +55,12 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   let isInitialized = false;
 
   /**
-   * @type {any} A utility array that keeps track of the position numbers for the dataList listed in the thumbnail list, allows the user to move the dataList around by various means.
+   * @type {any} A utility array that keeps track of the position numbers for the dataList listed in the item list, allows the user to move the dataList around by various means.
    */
   let indexModel: any = {};
 
   /**
-   * @type {HTMLDivElement} The html element containing the thumbnail list.
+   * @type {HTMLDivElement} The html element containing the item list.
    */
   let container: HTMLDivElement;
 
@@ -137,8 +137,8 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
    * @returns void
    */
   function jumpTo(index: number) {
-    let canvasThumbnails = container.querySelectorAll(".thumbnail");
-    canvasThumbnails?.[index]?.scrollIntoView();
+    let canvasitems = container.querySelectorAll(".item");
+    canvasitems?.[index]?.scrollIntoView();
   }
 
   /**
@@ -242,7 +242,9 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
             let:data
           >
             <DynamicDragAndDropListItem bind:pos={indexModel[data["id"]].pos}>
-              <slot item={indexModel[data["id"]]} />
+              <div class="item">
+                <slot item={indexModel[data["id"]]} />
+              </div>
             </DynamicDragAndDropListItem>
           </VirtualScroll>
         </div>
@@ -254,7 +256,9 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
         key="id"
         let:data
       >
-        <slot item={indexModel[data["id"]]} />
+        <div class="item">
+          <slot item={indexModel[data["id"]]} />
+        </div>
       </VirtualScroll>
     {/if}
   {/if}

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -57,7 +57,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   /**
    * @type {any} A utility array that keeps track of the position numbers for the dataList listed in the item list, allows the user to move the dataList around by various means.
    */
-  let indexModel: any = {};
+  let indexModel: any[] = [];
 
   /**
    * @type {HTMLDivElement} The html element containing the item list.
@@ -95,11 +95,6 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   let list;
 
   /**
-   * @type {number} The length of the index model used to control the drag and drop menu
-   */
-  let indexModelLength = 0;
-
-  /**
    * @type {any} A variable that allows the developer to interact with each individual item in @var dataList in the parent component.
    */
   let item = {};
@@ -109,12 +104,13 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
    * @returns void
    */
   function setIndexModel() {
-    indexModel = {};
+    indexModel = [];
     for (let i = 0; i < dataList.length; i++) {
-      indexModel[dataList[i].id] = {
+      indexModel.push({
+        id: i,
         pos: i + 1,
-        ...dataList[i],
-      };
+        data: { ...dataList[i] },
+      });
     }
   }
 
@@ -213,20 +209,12 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
     dataList;
     updated();
   }
-
-  /**
-   * @listens indexModel
-   * @description Sets @var indexModelLength, the dataList positions model, and stores the h any time the indexModel changes.
-   */
-  $: {
-    indexModelLength = Object.keys(indexModel).length;
-  }
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
 
 <div bind:this={container} tabindex="0" class="list" class:disabled>
-  {#if indexModelLength === dataList.length}
+  {#if indexModel.length === dataList.length}
     {#if draggable}
       <DynamicDragAndDropList
         bind:dragList={dataList}
@@ -257,7 +245,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
         let:data
       >
         <div class="item">
-          <slot item={indexModel[data["id"]]} />
+          <slot item={indexModel[data["index"]]} />
         </div>
       </VirtualScroll>
     {/if}
@@ -269,7 +257,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
     position: relative;
     flex: 9;
     width: 100%;
-    overflow-y: auto;
+    overflow-y: hidden;
     outline: none !important;
   }
   .list.disabled {

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -112,6 +112,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
         data: { ...dataList[i] },
       });
     }
+    indexModel = indexModel;
   }
 
   /**
@@ -245,7 +246,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
         let:data
       >
         <div class="item">
-          <slot item={indexModel[data["index"]]} />
+          <slot item={indexModel[data["id"]]} />
         </div>
       </VirtualScroll>
     {/if}

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -270,8 +270,9 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
     position: relative;
     flex: 9;
     width: 100%;
-    overflow-y: hidden;
     outline: none !important;
+    height: 77vh;
+    overflow-y: auto;
   }
   .list.disabled {
     overflow-y: hidden;

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -280,4 +280,8 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   .vs-wrap {
     height: 72vh;
   }
+
+  :global(.disabled .vs-wrap div) {
+    overflow-y: hidden !important;
+  }
 </style>

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -58,12 +58,14 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
    * @type {{
         id: number,
         pos: number,
+        new: boolean,
         data,
       }} A utility array that keeps track of the position numbers for the dataList listed in the item list, allows the user to move the dataList around by various means.
    */
   let indexModel: {
     id: number;
     pos: number;
+    new: boolean;
     data;
   }[] = [];
 
@@ -112,11 +114,13 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
    * @returns void
    */
   function setIndexModel() {
+    const prevArrLen = indexModel.length;
     indexModel = [];
     for (let i = 0; i < dataList.length; i++) {
       indexModel.push({
         id: i,
         pos: i + 1,
+        new: prevArrLen != 0 && i < dataList.length - prevArrLen,
         data: { ...dataList[i] },
       });
     }

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -55,22 +55,12 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   let isInitialized = false;
 
   /**
-   * @type {{
-        id: number,
-        pos: number,
-        new: boolean,
-        data,
-      }} A utility array that keeps track of the position numbers for the dataList listed in the item list, allows the user to move the dataList around by various means.
+   * @type {any} A utility array that keeps track of the position numbers for the dataList listed in the thumbnail list, allows the user to move the dataList around by various means.
    */
-  let indexModel: {
-    id: number;
-    pos: number;
-    new: boolean;
-    data;
-  }[] = [];
+  let indexModel: any = {};
 
   /**
-   * @type {HTMLDivElement} The html element containing the item list.
+   * @type {HTMLDivElement} The html element containing the thumbnail list.
    */
   let container: HTMLDivElement;
 
@@ -105,6 +95,11 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   let list;
 
   /**
+   * @type {number} The length of the index model used to control the drag and drop menu
+   */
+  let indexModelLength = 0;
+
+  /**
    * @type {any} A variable that allows the developer to interact with each individual item in @var dataList in the parent component.
    */
   let item = {};
@@ -114,15 +109,12 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
    * @returns void
    */
   function setIndexModel() {
-    const prevArrLen = indexModel.length;
-    indexModel = [];
+    indexModel = {};
     for (let i = 0; i < dataList.length; i++) {
-      indexModel.push({
-        id: i,
+      indexModel[dataList[i].id] = {
         pos: i + 1,
-        new: prevArrLen != 0 && i < dataList.length - prevArrLen,
-        data: { ...dataList[i] },
-      });
+        ...dataList[i],
+      };
     }
   }
 
@@ -145,8 +137,8 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
    * @returns void
    */
   function jumpTo(index: number) {
-    let canvasitems = container.querySelectorAll(".item");
-    canvasitems?.[index]?.scrollIntoView();
+    let canvasThumbnails = container.querySelectorAll(".thumbnail");
+    canvasThumbnails?.[index]?.scrollIntoView();
   }
 
   /**
@@ -221,12 +213,20 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
     dataList;
     updated();
   }
+
+  /**
+   * @listens indexModel
+   * @description Sets @var indexModelLength, the dataList positions model, and stores the h any time the indexModel changes.
+   */
+  $: {
+    indexModelLength = Object.keys(indexModel).length;
+  }
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
 
 <div bind:this={container} tabindex="0" class="list" class:disabled>
-  {#if indexModel.length === dataList.length}
+  {#if indexModelLength === dataList.length}
     {#if draggable}
       <DynamicDragAndDropList
         bind:dragList={dataList}
@@ -242,9 +242,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
             let:data
           >
             <DynamicDragAndDropListItem bind:pos={indexModel[data["id"]].pos}>
-              <div class="item">
-                <slot item={indexModel[data["id"]]} />
-              </div>
+              <slot item={indexModel[data["id"]]} />
             </DynamicDragAndDropListItem>
           </VirtualScroll>
         </div>
@@ -256,9 +254,7 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
         key="id"
         let:data
       >
-        <div class="item">
-          <slot item={indexModel[data["index"]]} />
-        </div>
+        <slot item={indexModel[data["id"]]} />
       </VirtualScroll>
     {/if}
   {/if}
@@ -269,9 +265,8 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
     position: relative;
     flex: 9;
     width: 100%;
-    outline: none !important;
-    height: 77vh;
     overflow-y: auto;
+    outline: none !important;
   }
   .list.disabled {
     overflow-y: hidden;
@@ -280,9 +275,5 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
 
   .vs-wrap {
     height: 72vh;
-  }
-
-  :global(.disabled .vs-wrap div) {
-    overflow-y: hidden !important;
   }
 </style>

--- a/services/admin/src/lib/components/shared/VirtualList.svelte
+++ b/services/admin/src/lib/components/shared/VirtualList.svelte
@@ -55,9 +55,17 @@ Displays a list that when scrolls veritcally, creates and distoys children eleme
   let isInitialized = false;
 
   /**
-   * @type {any} A utility array that keeps track of the position numbers for the dataList listed in the item list, allows the user to move the dataList around by various means.
+   * @type {{
+        id: number,
+        pos: number,
+        data,
+      }} A utility array that keeps track of the position numbers for the dataList listed in the item list, allows the user to move the dataList around by various means.
    */
-  let indexModel: any[] = [];
+  let indexModel: {
+    id: number;
+    pos: number;
+    data;
+  }[] = [];
 
   /**
    * @type {HTMLDivElement} The html element containing the item list.

--- a/services/admin/static/style.css
+++ b/services/admin/static/style.css
@@ -28,6 +28,8 @@
   /* App Theme */
   /* Change this to set the app bg color */
   --base-bg: white;
+  /* Change this to set the app bg color */
+  --light-bg: #f8f8f8;
   /* Change this to set the toolbar, tables, menus etc. colour */
   --structural-div-bg: var(--grey-light);
   /* Change this to set the bg color for components that need a darker backgrop, ex: canvas viewer */


### PR DESCRIPTION
You may need to run pnpm install, there's a new virtual scrolling library added

The behaviour is added to the general info tab, for collections only.

The only options are: unordered, multi-part.

If the collection is unordered, the user can only delete items, not re-order them in the manage members tab.