### PR TITLE
Finding manifests with a large number of canvases

### DIFF
--- a/services/couchdb/access/design/tree/views/canvases.js
+++ b/services/couchdb/access/design/tree/views/canvases.js
@@ -1,0 +1,7 @@
+module.exports = {
+  map: function (doc) {
+    if (Array.isArray(doc.canvases) && doc.canvases.length > 0)
+      emit(doc.canvases.length, doc.slug);
+  },
+  reduce: "_count",
+};


### PR DESCRIPTION
This is a suggestion for a view so we can find the most interesting manifests to test with when using the production database.

It may also suggests specific IDs that are worth pulling into our development fixtures.