### PR TITLE
Changes required to support separating of OCR data processing from Smelter.

### DIFF
--- a/packages/data/src/import/LegacyPackage.ts
+++ b/packages/data/src/import/LegacyPackage.ts
@@ -76,6 +76,11 @@ export const LegacyPackage = z.object({
   smelt: SmeltProcess.optional(),
 
   /**
+   * Request to extract OCR information from his package.
+   */
+   ocr: SmeltProcess.optional(),
+
+   /**
    * A record of the staff member who caused this record to be updated.
    */
   staff: StaffUpdate.optional(),

--- a/services/couchdb/canvas/design/access/views/cihmsourcepath.js
+++ b/services/couchdb/canvas/design/access/views/cihmsourcepath.js
@@ -3,6 +3,5 @@ module.exports = {
     if (typeof doc.source == "object" && doc.source.from === "cihm") {
       emit(doc.source.path, null);
     }
-  },
-  reduce: "_count",
+  }
 };

--- a/services/couchdb/canvas/design/access/views/copycanvasfiles.js
+++ b/services/couchdb/canvas/design/access/views/copycanvasfiles.js
@@ -1,10 +1,6 @@
 module.exports = {
   map: function (doc) {
-    if (
-      doc.orphan !== true &&
-      (("master" in doc && "path" in doc.master) ||
-        ("ocrPdf" in doc && "path" in doc.ocrPdf))
-    ) {
+    if (doc.orphan !== true && "master" in doc && "path" in doc.master) {
       emit(null, null);
     }
   },

--- a/services/couchdb/dipstaging/design/access/updates/cancelOCR.js
+++ b/services/couchdb/dipstaging/design/access/updates/cancelOCR.js
@@ -3,7 +3,7 @@ module.exports = function (doc, req) {
     successReturn,
     errorReturn,
     extractJSONFromBody,
-    timestamp,
+    updateGenericObject,
   } = require("views/lib/prelude");
 
   if (!doc) {
@@ -15,12 +15,9 @@ module.exports = function (doc, req) {
     return errorReturn(`Could not parse request body as JSON: ${req.body}`);
   }
 
-  const now = timestamp();
-
   const { user } = data;
+  updateGenericObject(doc, user);
 
-  doc.user = user;
-  doc.updated = now;
   delete doc.ocr;
 
   return successReturn(doc, "ok");

--- a/services/couchdb/dipstaging/design/access/updates/cancelOCR.js
+++ b/services/couchdb/dipstaging/design/access/updates/cancelOCR.js
@@ -1,0 +1,27 @@
+module.exports = function (doc, req) {
+  const {
+    successReturn,
+    errorReturn,
+    extractJSONFromBody,
+    timestamp,
+  } = require("views/lib/prelude");
+
+  if (!doc) {
+    return errorReturn(`No document found with id ${req.id}`, 404);
+  }
+
+  const data = extractJSONFromBody(req);
+  if (!data) {
+    return errorReturn(`Could not parse request body as JSON: ${req.body}`);
+  }
+
+  const now = timestamp();
+
+  const { user } = data;
+
+  doc.user = user;
+  doc.updated = now;
+  delete doc.smelt;
+
+  return successReturn(doc, "ok");
+};

--- a/services/couchdb/dipstaging/design/access/updates/cancelOCR.js
+++ b/services/couchdb/dipstaging/design/access/updates/cancelOCR.js
@@ -21,7 +21,7 @@ module.exports = function (doc, req) {
 
   doc.user = user;
   doc.updated = now;
-  delete doc.smelt;
+  delete doc.ocr;
 
   return successReturn(doc, "ok");
 };

--- a/services/couchdb/dipstaging/design/access/updates/cancelSmelt.js
+++ b/services/couchdb/dipstaging/design/access/updates/cancelSmelt.js
@@ -3,7 +3,7 @@ module.exports = function (doc, req) {
     successReturn,
     errorReturn,
     extractJSONFromBody,
-    timestamp,
+    updateGenericObject,
   } = require("views/lib/prelude");
 
   if (!doc) {
@@ -15,12 +15,9 @@ module.exports = function (doc, req) {
     return errorReturn(`Could not parse request body as JSON: ${req.body}`);
   }
 
-  const now = timestamp();
-
   const { user } = data;
+  updateGenericObject(doc, user);
 
-  doc.user = user;
-  doc.updated = now;
   delete doc.smelt;
 
   return successReturn(doc, "ok");

--- a/services/couchdb/dipstaging/design/access/updates/requestOCR.js
+++ b/services/couchdb/dipstaging/design/access/updates/requestOCR.js
@@ -3,6 +3,7 @@ module.exports = function (doc, req) {
     successReturn,
     errorReturn,
     extractJSONFromBody,
+    updateGenericObject,
     timestamp,
   } = require("views/lib/prelude");
 
@@ -15,12 +16,10 @@ module.exports = function (doc, req) {
     return errorReturn(`Could not parse request body as JSON: ${req.body}`);
   }
 
-  const now = timestamp();
-
   const { user } = data;
+  updateGenericObject(doc, user);
 
-  doc.user = user;
-  doc.updated = now;
+  const now = timestamp();
   doc.ocr = { requestDate: now };
 
   return successReturn(doc, "ok");

--- a/services/couchdb/dipstaging/design/access/updates/requestOCR.js
+++ b/services/couchdb/dipstaging/design/access/updates/requestOCR.js
@@ -1,0 +1,28 @@
+module.exports = function (doc, req) {
+  const {
+    successReturn,
+    errorReturn,
+    extractJSONFromBody,
+    timestamp,
+  } = require("views/lib/prelude");
+
+  if (!doc) {
+    return errorReturn(`No document found with id ${req.id}`, 404);
+  }
+
+  const data = extractJSONFromBody(req);
+  if (!data) {
+    return errorReturn(`Could not parse request body as JSON: ${req.body}`);
+  }
+
+  const now = timestamp();
+
+  const { user, slug } = data;
+
+  doc.user = user;
+  doc.slug = slug;
+  doc.updated = now;
+  doc.smelt = { requestDate: now };
+
+  return successReturn(doc, "ok");
+};

--- a/services/couchdb/dipstaging/design/access/updates/requestOCR.js
+++ b/services/couchdb/dipstaging/design/access/updates/requestOCR.js
@@ -17,12 +17,11 @@ module.exports = function (doc, req) {
 
   const now = timestamp();
 
-  const { user, slug } = data;
+  const { user } = data;
 
   doc.user = user;
-  doc.slug = slug;
   doc.updated = now;
-  doc.smelt = { requestDate: now };
+  doc.ocr = { requestDate: now };
 
   return successReturn(doc, "ok");
 };

--- a/services/couchdb/dipstaging/design/access/updates/requestSmelt.js
+++ b/services/couchdb/dipstaging/design/access/updates/requestSmelt.js
@@ -3,6 +3,7 @@ module.exports = function (doc, req) {
     successReturn,
     errorReturn,
     extractJSONFromBody,
+    updateGenericObject,
     timestamp,
   } = require("views/lib/prelude");
 
@@ -15,13 +16,15 @@ module.exports = function (doc, req) {
     return errorReturn(`Could not parse request body as JSON: ${req.body}`);
   }
 
-  const now = timestamp();
-
   const { user, slug } = data;
 
-  doc.user = user;
-  doc.slug = slug;
-  doc.updated = now;
+  updateGenericObject(doc, user);
+
+  if (typeof slug === "string") {
+    doc.slug = slug;
+  }
+
+  const now = timestamp();
   doc.smelt = { requestDate: now };
 
   return successReturn(doc, "ok");

--- a/services/couchdb/dipstaging/design/access/views/ocrQueue.js
+++ b/services/couchdb/dipstaging/design/access/views/ocrQueue.js
@@ -1,0 +1,15 @@
+module.exports = {
+  map: function (doc) {
+    const { parseTimestamp, dateAsArray } = require("views/lib/prelude");
+
+    const update = doc.ocr;
+    if (update) {
+      const requestDate = parseTimestamp(update.requestDate);
+      const processDate = parseTimestamp(update.processDate);
+      if (processDate < requestDate) {
+        emit(dateAsArray(requestDate), null);
+      }
+    }
+  },
+  reduce: "_count",
+};

--- a/services/couchdb/dipstaging/design/access/views/ocrStatus.js
+++ b/services/couchdb/dipstaging/design/access/views/ocrStatus.js
@@ -1,0 +1,15 @@
+module.exports = {
+  map: function (doc) {
+    const { parseTimestamp, dateAsArray } = require("views/lib/prelude");
+
+    const update = doc.ocr;
+    if (update) {
+      const requestDate = parseTimestamp(update.requestDate);
+      const processDate = parseTimestamp(update.processDate);
+      if (!!update.message && processDate >= requestDate) {
+        emit([update.succeeded, ...dateAsArray(processDate)], update.message);
+      }
+    }
+  },
+  reduce: "_count",
+};

--- a/services/couchdb/prelude.js
+++ b/services/couchdb/prelude.js
@@ -89,6 +89,23 @@ exports.updateObject = (doc, user) => {
 };
 
 /**
+ * Updates the fields that change when an Access Object is edited. Creates an internalmeta request.
+ * @param {Record<string, string>} doc The Access Object's document.
+ * @param {{name: string; email: string} | undefined} user The user who triggered this update, if one exists.
+ */
+ exports.updateGenericObject = (doc, user) => {
+  const now = exports.timestamp();
+  if (
+    typeof user === "object" &&
+    typeof user.email === "string" &&
+    typeof user.name === "string"
+  ) {
+    doc.staff = { by: user, date: now };
+  }
+  doc.updated = now;
+};
+
+/**
  * Returns a completed ProcessUpdate.
  * @param {update} update The pending ProcessUpdate.
  * @param {boolean} succeeded Whether the process succeeded.


### PR DESCRIPTION
This is related to https://github.com/crkn-rcdr/Access-Platform/issues/368

* Smelter will look up to see if image canvases already exist using [_view/cihmsource](https://github.com/crkn-rcdr/Access-Platform/blob/main/services/couchdb/canvas/design/access/views/cihmsource.js) , and create the canvases otherwise.
* Re-smelting can't be used to add OCR to images that have already been smelted, so a different process will exist that will find the OCR that matches the image, and attach that to the canvas.
* The UI should allow people the option of processing the OCR.  This can use the same tool as smelting, but should be different button as they may happen at different times.
