### PR TITLE
Membership display / editing

### DIFF
--- a/packages/couch-utils/src/handlers/access.ts
+++ b/packages/couch-utils/src/handlers/access.ts
@@ -14,6 +14,9 @@ import {
   NewCollection,
   NewManifest,
   TextRecord,
+  SimpleRecord,
+  Membership,
+  Ancestry,
 } from "@crkn-rcdr/access-data";
 
 import { DatabaseHandler } from "../DatabaseHandler.js";
@@ -34,15 +37,6 @@ type SlugResolutionError =
   | "not-found" // the slug didn't resolve
   | "is-self" // the slug resolved to the collection being edited
   | "already-member"; // the slug resolved to an existing member of the collection
-
-export interface SimpleRecord {
-  id: Noid;
-  slug?: Slug;
-  label: TextRecord;
-}
-
-export type Membership = Array<SimpleRecord>;
-export type Ancestry = Array<Array<SimpleRecord>>;
 
 export type ProcessListCommand =
   | ["add", Noid[]]

--- a/packages/data/src/access/index.ts
+++ b/packages/data/src/access/index.ts
@@ -4,6 +4,8 @@ import { Alias } from "./Alias.js";
 import { Canvas } from "./Canvas.js";
 import { Collection } from "./Collection.js";
 import { Manifest } from "./Manifest.js";
+import { Noid, Slug } from "../util/index.js";
+import { TextRecord } from "./util/TextRecord.js";
 
 export const AccessObject = z.union([Alias, Canvas, Collection, Manifest]);
 export type AccessObject = z.infer<typeof AccessObject>;
@@ -50,3 +52,12 @@ export {
   ObjectListPage,
 } from "./util/ObjectList.js";
 export { TextRecord } from "./util/TextRecord.js";
+
+export interface SimpleRecord {
+  id: Noid;
+  slug?: Slug;
+  label: TextRecord;
+}
+
+export type Membership = Array<SimpleRecord>;
+export type Ancestry = Array<Array<SimpleRecord>>;

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -25,6 +25,9 @@ export {
   isManifest,
   toPagedCollection,
   toPagedManifest,
+  SimpleRecord,
+  Membership,
+  Ancestry,
 } from "./access/index.js";
 
 export {

--- a/services/admin/src/lib/components/access-objects/Editor.svelte
+++ b/services/admin/src/lib/components/access-objects/Editor.svelte
@@ -15,7 +15,7 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
 *Note: `bind:` is required for changes to the serverObject to be reflected in higher level components.*
 -->
 <script lang="ts">
-  import type { AccessObject } from "@crkn-rcdr/access-data";
+  import type { AccessObject, Membership } from "@crkn-rcdr/access-data";
   import { isManifest, isCollection } from "@crkn-rcdr/access-data";
   import type { SideMenuPageData } from "$lib/types";
   import Toolbar from "$lib/components/shared/Toolbar.svelte";
@@ -30,6 +30,8 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
    * @type {AccessObject} Object being edited.
    */
   export let serverObject: AccessObject;
+
+  export let membership: Membership;
 
   /**
    * @type {Array<SideMenuPageData>} This list controls the pages that appear in the side menu container, and their contents.
@@ -53,19 +55,22 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
    */
   async function setPageList() {
     if (!serverObject || !editorObject) return;
+
+    const generalInfo = {
+      name: "General Info",
+      componentData: {
+        contentComponent: InfoEditor,
+        contentComponentProps: { editorObject, membership },
+        sideMenuPageProps: {},
+        update: () => {
+          editorObject = editorObject;
+        },
+      },
+    };
+
     if (isManifest(editorObject)) {
       pageList = [
-        {
-          name: "General Info",
-          componentData: {
-            contentComponent: InfoEditor,
-            contentComponentProps: { editorObject: editorObject },
-            sideMenuPageProps: {},
-            update: () => {
-              editorObject = editorObject;
-            },
-          },
-        },
+        generalInfo,
         {
           name: "Manage Content",
           componentData: {
@@ -82,17 +87,7 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
       ];
     } else if (isCollection(editorObject)) {
       pageList = [
-        {
-          name: "General Info",
-          componentData: {
-            contentComponent: InfoEditor,
-            contentComponentProps: { editorObject: editorObject },
-            sideMenuPageProps: {},
-            update: () => {
-              editorObject = editorObject;
-            },
-          },
-        },
+        generalInfo,
         {
           name: "Manage Members",
           componentData: {

--- a/services/admin/src/lib/components/access-objects/Editor.svelte
+++ b/services/admin/src/lib/components/access-objects/Editor.svelte
@@ -54,7 +54,7 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
    * @returns void
    */
   async function setPageList() {
-    if (!serverObject || !editorObject) return;
+    if (!editorObject) return;
 
     const generalInfo = {
       name: "General Info",
@@ -129,14 +129,14 @@ The editor component allows for the editing of AccessObjects. It will dynamicall
   }
 </script>
 
-{#if serverObject && editorObject}
+{#if editorObject}
   <div class="editor">
     <SideMenuContainer {pageList}>
       <Toolbar
         slot="side-menu-header"
         title={serverObject?.["slug"]?.length
           ? serverObject["slug"]
-          : `Slugless ${serverObject["type"]}`}
+          : `Slugless ${serverObject.type}`}
       >
         <div
           class="end-content auto-align auto-align__full auto-align auto-align__j-end auto-align auto-align__a-end auto-align auto-align__column"

--- a/services/admin/src/lib/components/access-objects/InfoEditor.svelte
+++ b/services/admin/src/lib/components/access-objects/InfoEditor.svelte
@@ -16,15 +16,20 @@ This component displays the non content properties for an access editorObject an
 -->
 <script lang="ts">
   import { isManifest, isCollection } from "@crkn-rcdr/access-data";
-  import type { AccessObject } from "@crkn-rcdr/access-data";
-  import { getSlugValidationMsg, typedChecks } from "$lib/utils/validation";
+  import type { AccessObject, Membership } from "@crkn-rcdr/access-data";
+  import { typedChecks } from "$lib/utils/validation";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
   import Resolver from "$lib/components/access-objects/Resolver.svelte";
 
   /**
-   * @type {AccessObject} The AccessObject editorObject that will be manipulated by the user, usually, a copy of an access pbject that acts as a form model.
+   * The AccessObject editorObject that will be manipulated by the user, usually, a copy of an access pbject that acts as a form model.
    */
   export let editorObject: AccessObject; // Not sure if we should pass an editorObject or have a list of props (ex: slug, label, ...) that can be null, and show ones that are instantiated only?
+
+  /**
+   * Membership record for this object.
+   */
+  export let membership: Membership;
 </script>
 
 {#if editorObject}
@@ -65,6 +70,19 @@ This component displays the non content properties for an access editorObject an
           <option>multi-part</option>
           <option>unordered</option>
         </select><br /><br />
+      {/if}
+
+      <p>Memberships</p>
+      {#if membership.length > 0}
+        <ul>
+          {#each membership as coll}
+            <li>
+              <a href="/object/{coll.id}">{coll.label["none"]} ({coll.slug})</a>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p>This {editorObject.type} is not a member of any collections.</p>
       {/if}
       <!--Fixtures don't have this yet, causes save to be enabled on load-->
 

--- a/services/admin/src/routes/object/[prefix]/[noid].svelte
+++ b/services/admin/src/routes/object/[prefix]/[noid].svelte
@@ -18,7 +18,7 @@
           "accessObject.getMembership",
           id
         );
-        return { props: { serverObject, membership } };
+        return { props: { serverObject, membership, id, error: "" } };
       }
       return { props: { error: "Could not find prefix or noid in url." } };
     } catch (e) {
@@ -34,10 +34,12 @@
    * The object is given to the page from the module above.
    */
   import { AccessObject } from "@crkn-rcdr/access-data";
-  import type { Membership } from "@crkn-rcdr/access-data";
+  import type { Membership, Noid } from "@crkn-rcdr/access-data";
   import Editor from "$lib/components/access-objects/Editor.svelte";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
   import Loading from "$lib/components/shared/Loading.svelte";
+
+  export let id: Noid;
 
   /**
    * @type {AccessObject} Object being edited.
@@ -53,18 +55,22 @@
    * @type {string} An error message insdicating what went wrong.
    */
   export let error: string;
+
+  // The `key` directive below reloads this component's contents when `id` changes.
 </script>
 
-{#if serverObject}
-  <Editor bind:serverObject {membership} />
-{:else if error}
-  <br />
-  <div class="wrapper">
-    <NotificationBar status="fail" message={error} />
-  </div>
-{:else}
-  <div class="wrapper center">
-    <Loading backgroundType="gradient" /><br />
-    Loading...
-  </div>
-{/if}
+{#key id}
+  {#if serverObject}
+    <Editor bind:serverObject {membership} />
+  {:else if error}
+    <br />
+    <div class="wrapper">
+      <NotificationBar status="fail" message={error} />
+    </div>
+  {:else}
+    <div class="wrapper center">
+      <Loading backgroundType="gradient" /><br />
+      Loading...
+    </div>
+  {/if}
+{/key}

--- a/services/admin/src/routes/object/[prefix]/[noid].svelte
+++ b/services/admin/src/routes/object/[prefix]/[noid].svelte
@@ -14,7 +14,11 @@
         ].join("/");
         const response = await context.lapin.query("accessObject.get", id);
         const serverObject = AccessObject.parse(response);
-        return { props: { serverObject } };
+        const membership = await context.lapin.query(
+          "accessObject.getMembership",
+          id
+        );
+        return { props: { serverObject, membership } };
       }
       return { props: { error: "Could not find prefix or noid in url." } };
     } catch (e) {
@@ -30,6 +34,7 @@
    * The object is given to the page from the module above.
    */
   import { AccessObject } from "@crkn-rcdr/access-data";
+  import type { Membership } from "@crkn-rcdr/access-data";
   import Editor from "$lib/components/access-objects/Editor.svelte";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
   import Loading from "$lib/components/shared/Loading.svelte";
@@ -40,13 +45,18 @@
   export let serverObject: AccessObject;
 
   /**
+   * Membership record for this object.
+   */
+  export let membership: Membership;
+
+  /**
    * @type {string} An error message insdicating what went wrong.
    */
   export let error: string;
 </script>
 
 {#if serverObject}
-  <Editor bind:serverObject />
+  <Editor bind:serverObject {membership} />
 {:else if error}
   <br />
   <div class="wrapper">

--- a/services/admin/static/style.css
+++ b/services/admin/static/style.css
@@ -1760,7 +1760,7 @@ span.flatpickr-day.nextMonthDay.selected {
   border-right: 0;
 }
 
-@media screen and (min-width: 0\0) and (min-resolution: +72dpi) {
+@media screen and (min-width: 0\0) and (min-resolution: 72dpi) {
   span.flatpickr-day {
     display: block;
     -webkit-box-flex: 1;


### PR DESCRIPTION
Closes #94, with the caveat that this isn't going to display the entire ancestry tree all at once, for probable performance nightmare reasons. Users can click links to view the collections this object is a member of, and can also remove the object's membership in a collection.

I'll also fix a bug in which components don't seem to reset properly when traversing between objects. This is a known Svelte issue (feature?) that we figured out how to work around in Sapindale.