### PR TITLE
Layout fixes for the add canvas menu on prod

### DIFF
--- a/services/admin/src/lib/components/access-objects/EditorActions.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorActions.svelte
@@ -265,32 +265,43 @@ The editor actions component holds functionality that is responsible for perform
     }
   }
 
-  async function setDeletionModalTextEnabled() {
+  function setDeletionModalTextEnabled() {
     deleteModalTitle = `Are you sure you want to delete ${serverObject["slug"]}?`;
     deleteModalMsg = `By deleting ${serverObject["slug"]}, you will be taking it out of all the collections it belongs to. You will be able to use the slug, "${serverObject["slug"]}", for future ${serverObject["type"]}s. You can add ${serverObject["slug"]} back into the access platform by importing it from preservation again.`;
     deleteModalActionText = `Delete`;
   }
 
-  async function setDeletionModalTextWaiting() {
+  function setDeletionModalTextWaiting() {
     deleteModalTitle = `${serverObject["slug"]} can't be deleted yet.`;
     deleteModalMsg = `There are background processes running preventing ${serverObject["slug"]} from being deleted. Please wait...`;
     deleteModalActionText = `Ok`;
   }
 
-  async function setDeletionModalTextTryAgain() {
+  function setDeletionModalTextTryAgain() {
     console.log("No tries left");
     deleteModalTitle = `${serverObject["slug"]} can not be deleted.`;
     deleteModalMsg = `Can not delete ${serverObject["slug"]}. There are background processes running on ${serverObject["slug"]}. Please wait and try again later.`;
     deleteModalActionText = `Ok`;
   }
 
+  function setDeletionModalTextError() {
+    deleteModalTitle = `${serverObject["slug"]} can't be deleted.`;
+    deleteModalMsg = `There was a problem when  background processes ran that is preventing ${serverObject["slug"]} from being deleted. Message: ${serverObject["updateInternalmeta"]?.["message"]}`;
+    deleteModalActionText = `Ok`;
+  }
+
   async function openDeletionModal() {
     if (
       !serverObject.updateInternalmeta ||
-      serverObject.updateInternalmeta?.["succeeded"]
+      "succeeded" in serverObject.updateInternalmeta
     ) {
-      isDeleteModalWaiting = false;
-      setDeletionModalTextEnabled();
+      if (serverObject.updateInternalmeta["succeeded"]) {
+        isDeleteModalWaiting = false;
+        setDeletionModalTextEnabled();
+      } else {
+        isDeleteModalWaiting = false;
+        setDeletionModalTextError();
+      }
     } else {
       isDeleteModalWaiting = true;
       setDeletionModalTextWaiting();
@@ -301,9 +312,14 @@ The editor actions component holds functionality that is responsible for perform
           console.log("pulling serverObject");
           await pullServerObject();
           console.log("pulled!", serverObject);
-          if (serverObject.updateInternalmeta?.["succeeded"]) {
-            isDeleteModalWaiting = false;
-            setDeletionModalTextEnabled();
+          if ("succeeded" in serverObject.updateInternalmeta) {
+            if (serverObject.updateInternalmeta["succeeded"]) {
+              isDeleteModalWaiting = false;
+              setDeletionModalTextEnabled();
+            } else {
+              isDeleteModalWaiting = false;
+              setDeletionModalTextError();
+            }
           } else {
             console.log("Update not done");
             //isDeleteModalWaiting = true;

--- a/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
+++ b/services/admin/src/lib/components/manifests/ManifestAddCanvasMenu.svelte
@@ -35,7 +35,8 @@ This component allows the user to search through other manifests and select canv
     Manifest,
     PagedManifest,
   } from "@crkn-rcdr/access-data/src/access/Manifest";
-
+  import FaCheckDouble from "svelte-icons/fa/FaCheckDouble.svelte";
+  import FaTimes from "svelte-icons/fa/FaTimes.svelte";
   import CanvasesSelector from "$lib/components/canvases/CanvasesSelector.svelte";
 
   /**
@@ -186,15 +187,15 @@ This component allows the user to search through other manifests and select canv
         <div
           data-tooltip={`${isAllSelected ? "Deselect" : "Select"} all`}
           data-tooltip-flow="bottom"
+          alt="select all"
+          on:click={() => (isAllSelected = !isAllSelected)}
+          class="icon select-all"
         >
-          <img
-            class="icon select-all"
-            src={`/static/icons/${
-              isAllSelected ? "deselect.png" : "select.svg"
-            }`}
-            alt="select all"
-            on:click={() => (isAllSelected = !isAllSelected)}
-          />
+          {#if isAllSelected}
+            <FaTimes />
+          {:else}
+            <FaCheckDouble />
+          {/if}
         </div>
 
         {#if selectedCanvases.length}
@@ -207,7 +208,7 @@ This component allows the user to search through other manifests and select canv
 
     {#if selectedManifest}
       {#if selectedManifest["canvases"] && selectedManifest["canvases"].length}
-        <div class="results full-page">
+        <div class="results full-page auto-align auto-align__column">
           <p class="title">
             <i
               >{selectedManifest.slug}{selectedManifest.label?.none?.length
@@ -319,7 +320,7 @@ This component allows the user to search through other manifests and select canv
   }
 
   .canvas-list-item-viewer {
-    height: 80vh;
+    flex: 10;
     width: 100%;
     position: relative;
     background: var(--darkest-bg);
@@ -332,7 +333,7 @@ This component allows the user to search through other manifests and select canv
     color: var(--secondary-light);
     background-color: var(--dark-bg);
     z-index: 1;
-    position: absolute;
+    /*position: absolute;*/
   }
 
   /*.title > h6 {
@@ -344,7 +345,7 @@ This component allows the user to search through other manifests and select canv
 
   :global(.add-menu .referencestrip) {
     left: 60px !important;
-    top: 3rem;
+    /*top: 3rem;*/
   }
 
   :global(.openseadragon-canvas) {


### PR DESCRIPTION
Hey @DivyaKrishnan26 I had to edit the add canvas menu to support long labels for the selected manifest. I also replaced the select all, deselect all icons because they were not being found on prod.