### PR TITLE
Ensure the process order of a DMD task always matches the table order

### DIFF
--- a/services/admin/src/lib/components/dmd/success/DmdSuccessView.svelte
+++ b/services/admin/src/lib/components/dmd/success/DmdSuccessView.svelte
@@ -78,6 +78,7 @@ This component shows the view for a dmd task that had its metadata successfully 
         };
       }
       dmdTasksStore.initializeTask(dmdTask.id, {
+        task: dmdTask,
         updateState: "ready",
         itemStates: items,
         resultMsg: "",

--- a/services/admin/src/lib/stores/dmdTasksStore.ts
+++ b/services/admin/src/lib/stores/dmdTasksStore.ts
@@ -127,9 +127,12 @@ async function storeTaskItemMetadata(
   let index = 0;
   let numUpdated = 0;
   let failedSlugs: string[] = [];
-  for (const itemSlug in items) {
+
+  for (const item of dmdTask.task.items) {
+    // To cause the process order to always match the drawn order.
+    const itemSlug = item.id;
     // Only run on items the user selects
-    if (items[itemSlug].shouldUpdate) {
+    if (items[itemSlug]?.shouldUpdate) {
       // Shows a loader
       items[itemSlug].updatedInAccess = "Updating";
       items[itemSlug].updatedInPreservation = "Updating";

--- a/services/admin/src/lib/types.ts
+++ b/services/admin/src/lib/types.ts
@@ -6,7 +6,13 @@
 
 import type { TRPCClient } from "@trpc/client";
 import type { LapinRouter } from "@crkn-rcdr/lapin-router";
-import type { Noid, Slug, User } from "@crkn-rcdr/access-data";
+import type {
+  DMDTask,
+  Noid,
+  Slug,
+  SucceededDMDTask,
+  User,
+} from "@crkn-rcdr/access-data";
 
 /**
  * Session exported by the `getSession` hook.
@@ -76,6 +82,7 @@ export type DmdItemState = {
 export type DmdItemStates = Map<string, DmdItemState>;
 
 export type DmdTaskState = {
+  task: SucceededDMDTask;
   updateState: "ready" | "updating" | "updated" | "error";
   itemStates: DmdItemStates;
   resultMsg: string;


### PR DESCRIPTION
Fixed so that the dmd task item list is used for iteration. 

The table was being processed in reverse for Natalie, which was being caused by the ids being in descending order!!

Closes #405 

We can see if we can simplify the dmd task logic in the future
