### PR TITLE
Importer bug-fix

### DIFF
--- a/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
@@ -237,10 +237,10 @@ This component allows the user to find packages in the dipstaging database.
       <label for="end">End date:</label><br />
       <input type="date" id="end" name="trip-end" bind:value={endDateStr} /-->
 
-      <span class="flatpickr-date-filter-label">Select dates:</span>
+      <span class="flatpickr-date-filter-label">Select date(s):</span>
       <br />
       <Datepicker
-        placeholder="Select dates"
+        placeholder="Select date(s)"
         bind:startDateStr
         bind:endDateStr
         options={{ mode: "range" }}

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
@@ -237,12 +237,10 @@ This component allows the user to find packages in the dipstaging database.
       <label for="end">End date:</label><br />
       <input type="date" id="end" name="trip-end" bind:value={endDateStr} /-->
 
-      <span class="flatpickr-date-filter-label"
-        >Select a date range (double click for a single date):</span
-      >
+      <span class="flatpickr-date-filter-label">Select dates:</span>
       <br />
       <Datepicker
-        placeholder="Select a date range"
+        placeholder="Select dates"
         bind:startDateStr
         bind:endDateStr
         options={{ mode: "range" }}

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -241,6 +241,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
 
 <NotificationBar message={error} status="fail" />
 
+<!-- check the slug resolvers are searching for slug not AIP if slug defined. -->
 {#if !loading}
   <div class="button-wrap" class:disabled={!items}>
     <button

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -88,7 +88,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
    */
   function toggleAllSelected(event) {
     for (const item of results) {
-      if (!slugUnavailableMap[item["id"]])
+      if (!slugUnavailableMap[item["slug"]] && isItemSelectable(item))
         selectedMap[item["id"]] = event.target.checked;
       else selectedMap[item["id"]] = false;
     }
@@ -131,7 +131,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
    * @returns void
    */
   function setSlugAvailability(event, item: ImportStatus | LegacyPackage) {
-    slugUnavailableMap[item["id"]] = !event.detail.status;
+    slugUnavailableMap[item["slug"]] = !event.detail.status;
     slugUnavailableMap = slugUnavailableMap;
     setSelectedModel();
   }
@@ -159,6 +159,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
    */
   function setSelectedModel() {
     if (!items) return;
+    selectedMap = {};
     for (const item of items) {
       if (!(item["id"] in selectedMap) && isItemSelectable(item))
         selectedMap[item["id"]] = true;
@@ -175,13 +176,14 @@ This component shows the results of a dipstaging find-package(s) request or a vi
     if ("status" in item) {
       return (
         !sucessfulSmeltRequestMap[item["id"]] &&
-        !slugUnavailableMap[item["id"]] &&
+        !slugUnavailableMap[item["slug"]] &&
         item["status"] !== "not-found" &&
         item["status"] !== "processing"
       );
     } else {
       return (
-        !sucessfulSmeltRequestMap[item["id"]] && !slugUnavailableMap[item["id"]]
+        !sucessfulSmeltRequestMap[item["id"]] &&
+        !slugUnavailableMap[item["slug"]]
       );
     }
   }
@@ -224,11 +226,9 @@ This component shows the results of a dipstaging find-package(s) request or a vi
   $: {
     loading = true;
     results;
-    Promise.all([
-      checkIfSlugsDefined(),
-      getSlugAvailability(),
-      setSelectedModel(),
-    ]).then(() => {
+    checkIfSlugsDefined();
+    getSlugAvailability().then(() => {
+      setSelectedModel();
       loading = false;
     });
   }
@@ -275,7 +275,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
           <tr>
             <td>
               <div class="row auto-align">
-                {#if !slugUnavailableMap[item["id"]] && !("status" in item && item.status === "processing") && !("status" in item && item.status === "not-found")}
+                {#if !slugUnavailableMap[item["slug"]] && !("status" in item && item.status === "processing") && !("status" in item && item.status === "not-found")}
                   <div class="row-check">
                     <input
                       type="checkbox"
@@ -307,7 +307,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   >Track its status in the 'Import Queue' tab.</a
                 >
               {:else}
-                {#if slugUnavailableMap[item["id"]] && slugMap[item["id"]] === item["id"]}
+                {#if slugUnavailableMap[item["slug"]] && slugMap[item["id"]] === item["id"]}
                   <NotificationBar
                     status="fail"
                     message={`The AIP ID for this package is already a slug for an existing manifest.`}
@@ -329,7 +329,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   <button
                     class="secondary"
                     on:click={() => {
-                      slugUnavailableMap[item["id"]] = false;
+                      slugUnavailableMap[item["slug"]] = false;
                     }}
                   >
                     OK, I have deleted the manifest.
@@ -341,7 +341,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   </span>
                   <Resolver
                     noid={item["id"] in noidMap ? noidMap[item["id"]] : null}
-                    isFound={slugUnavailableMap[item["id"]]}
+                    isFound={slugUnavailableMap[item["slug"]]}
                     alwaysShowIfFound={true}
                     runInitial={true}
                     on:available={(e) => setSlugAvailability(e, item)}

--- a/services/admin/src/routes/smelter/[view]/__layout.svelte
+++ b/services/admin/src/routes/smelter/[view]/__layout.svelte
@@ -159,7 +159,7 @@
       <div class="auto-align auto-align__a-center">
         {#if dates && dates.length === 2}
           <Datepicker
-            placeholder="Select dates"
+            placeholder="Select date(s)"
             bind:startDateStr={dates[0]}
             bind:endDateStr={dates[1]}
             options={{ mode: "range" }}

--- a/services/admin/src/routes/smelter/[view]/__layout.svelte
+++ b/services/admin/src/routes/smelter/[view]/__layout.svelte
@@ -159,7 +159,7 @@
       <div class="auto-align auto-align__a-center">
         {#if dates && dates.length === 2}
           <Datepicker
-            placeholder="Select a date range"
+            placeholder="Select dates"
             bind:startDateStr={dates[0]}
             bind:endDateStr={dates[1]}
             options={{ mode: "range" }}


### PR DESCRIPTION
Closes #430 

To test please go to packages with recent activity -> find a manifest with an unavailable slug -> enter a slug that is available -> select it -> press import -> go to queue and see that the slug you entered is marked as available. 

I can make this queue view have a non-editable slug after fix is confirmed too, since it really shouldn't be an input there.