### PR TITLE
Adding links to helper icons

### DIFF
--- a/Help.md
+++ b/Help.md
@@ -10,6 +10,6 @@ This repository contains documentation, Glossary for the Canadiana Access Platfo
 
 ### [Editor Actions Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg
 
-## Metada Helper
+## Smelter Helper
 
-### [Metadata/DMD Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg
+### [Smelter/DMD Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg

--- a/Help.md
+++ b/Help.md
@@ -4,12 +4,12 @@ This repository contains documentation, Glossary for the Canadiana Access Platfo
 
 ## Helper Directory
 
-### [Glossary.md](Glossary.md) https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md
+### [Glossary.md](https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md)
 
 ## Editor Helper
 
-### [Editor Actions Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg
+### [Editor Actions Guide](https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg)
 
 ## Smelter Helper
 
-### [Smelter/DMD Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg
+### [Smelter/DMD Guide](https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg)

--- a/Helper.md
+++ b/Helper.md
@@ -1,0 +1,15 @@
+# Canadiana Access Platform
+
+This repository contains documentation, Glossary for the Canadiana Access Platform.
+
+## Helper Directory
+
+### [Glossary.md](Glossary.md) https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md
+
+## Editor Helper
+
+### [Editor Actions Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg
+
+## Metada Helper
+
+### [Metadata/DMD Guide] https://crkn.sharepoint.com/:w:/s/platform/EcbVMYIYRjtMpR9RDDSCGCYBhdRZyqiInOlAvs2jRLdCdg

--- a/services/admin/src/routes/__layout.svelte
+++ b/services/admin/src/routes/__layout.svelte
@@ -109,7 +109,7 @@
     <a
       href="https://github.com/crkn-rcdr/Access-Platform/blob/adding_help_link/Help.md"
       target="_blank"
-      data-tooltip="Click for help!"
+      data-tooltip="Click for Glossary and Guides!"
       data-tooltip-flow="bottom">
       <div class="icon">
         <FaRegQuestionCircle />

--- a/services/admin/src/routes/__layout.svelte
+++ b/services/admin/src/routes/__layout.svelte
@@ -31,6 +31,7 @@
    */
   import FaRegQuestionCircle from "svelte-icons/fa/FaRegQuestionCircle.svelte";
   import FaRegUserCircle from "svelte-icons/fa/FaRegUserCircle.svelte";
+  import GoMarkGithub from "svelte-icons/go/GoMarkGithub.svelte";
   import { getStores, page } from "$app/stores";
   import DropdownMenu from "$lib/components/shared/DropdownMenu.svelte";
   import { includes } from "lodash-es";
@@ -104,12 +105,21 @@
   
   <div class="right-menu auto-align auto-align__a-center">
     <a
-      href="https://github.com/crkn-rcdr/Access-Platform/issues"
+      href="https://github.com/crkn-rcdr/Access-Platform/discussions/389"
       target="_blank"
       data-tooltip="Click for help!"
       data-tooltip-flow="bottom">
       <div class="icon">
         <FaRegQuestionCircle />
+      </div>
+    </a>
+    <a
+      href="https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md"
+      target="_blank"
+      data-tooltip="Glossary!"
+      data-tooltip-flow="bottom">
+      <div class="icon">
+        <GoMarkGithub />
       </div>
     </a>
     <DropdownMenu direction="right">

--- a/services/admin/src/routes/__layout.svelte
+++ b/services/admin/src/routes/__layout.svelte
@@ -107,7 +107,7 @@
   <div class="right-menu auto-align auto-align__a-center">
  
     <a
-      href=" https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md"
+      href="https://github.com/crkn-rcdr/Access-Platform/blob/adding_help_link/Help.md"
       target="_blank"
       data-tooltip="Click for help!"
       data-tooltip-flow="bottom">

--- a/services/admin/src/routes/__layout.svelte
+++ b/services/admin/src/routes/__layout.svelte
@@ -31,10 +31,11 @@
    */
   import FaRegQuestionCircle from "svelte-icons/fa/FaRegQuestionCircle.svelte";
   import FaRegUserCircle from "svelte-icons/fa/FaRegUserCircle.svelte";
-  import GoMarkGithub from "svelte-icons/go/GoMarkGithub.svelte";
+
   import { getStores, page } from "$app/stores";
   import DropdownMenu from "$lib/components/shared/DropdownMenu.svelte";
   import { includes } from "lodash-es";
+  import Align from "$lib/components/shared/Align.svelte";
 
   /**
    * @type {TRPCClient<LapinRouter>} Allows the app to to speak to the lapin api
@@ -104,8 +105,9 @@
   {/if}
   
   <div class="right-menu auto-align auto-align__a-center">
+ 
     <a
-      href="https://github.com/crkn-rcdr/Access-Platform/discussions/389"
+      href=" https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md"
       target="_blank"
       data-tooltip="Click for help!"
       data-tooltip-flow="bottom">
@@ -113,15 +115,8 @@
         <FaRegQuestionCircle />
       </div>
     </a>
-    <a
-      href="https://github.com/crkn-rcdr/Access-Platform/blob/main/Glossary.md"
-      target="_blank"
-      data-tooltip="Glossary!"
-      data-tooltip-flow="bottom">
-      <div class="icon">
-        <GoMarkGithub />
-      </div>
-    </a>
+    
+   
     <DropdownMenu direction="right">
       <div slot="dropdown-button" class="icon">
         <FaRegUserCircle />


### PR DESCRIPTION
https://github.com/crkn-rcdr/Access-Platform/issues/402

For the issue linked above I have added a link to Glossary and the Editor actions show and tell documentation, Let me know if thats fine or do we want to change the link to something else.