### PR TITLE
Indexing `manifest_noid` rather than `pkey`.  

### DIFF
--- a/services/couchdb/copresentation2/design/access/views/manifest_noid.js
+++ b/services/couchdb/copresentation2/design/access/views/manifest_noid.js
@@ -1,8 +1,8 @@
 // Used by Press2
 module.exports = {
   map: function (doc) {
-    if ("pkey" in doc) {
-      emit(doc.pkey, null);
+    if ("manifest_noid" in doc) {
+      emit(doc.manifest_noid, null);
     }
   },
 };

--- a/services/couchdb/cosearch2/design/access/views/manifest_noid.js
+++ b/services/couchdb/cosearch2/design/access/views/manifest_noid.js
@@ -1,8 +1,8 @@
 // Used by Press2
 module.exports = {
   map: function (doc) {
-    if ("pkey" in doc) {
-      emit(doc.pkey, null);
+    if ("manifest_noid" in doc) {
+      emit(doc.manifest_noid, null);
     }
   },
 };

--- a/services/couchdb/internalmeta2/design/tdr/updates/basic.js
+++ b/services/couchdb/internalmeta2/design/tdr/updates/basic.js
@@ -64,6 +64,10 @@ module.exports = function (doc, req) {
     doc["METSDate"] = nowdates;
     updated = true;
   }
+  if ("noid" in updatedoc && doc["noid"] !== updatedoc["noid"]) {
+    doc["noid"] = updatedoc["noid"];
+    updated = true;
+  }
   if ("type" in updatedoc && doc["type"] !== updatedoc["type"]) {
     doc["type"] = updatedoc["type"];
     updated = true;


### PR DESCRIPTION
This will be used to remve pages when a manifest is removed, rather than making assumptions about the structure of a slug (there may be more than one `.`)

See https://github.com/crkn-rcdr/Access-Platform/issues/400