### PR TITLE
Force updates for collection members when important fields change, and force update parent collections when manifests updated

### DIFF
--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -124,14 +124,6 @@ function chunkArray(array: any[], n: number) {
 }
 
 /**
- * A helper method to slow down the rate of requests going to the backend. Causes the script to pause for 'ms.'
- * @param ms
- */
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
  * Handler for interactions with a CouchDB database.
  *
  * Also handles translating `_id` and `_attachments` to non-underscored versions.
@@ -195,6 +187,7 @@ export class DatabaseHandler<T extends Document> {
   /**
    * Updates all the objects in ids
    * @param ids Id strings for the objects to be updated
+   * @param changeMethod A function that returns the following: [<new document>, <message>]
    * @returns the result of the bulk update
    *
    * See: https://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-docs
@@ -221,18 +214,22 @@ export class DatabaseHandler<T extends Document> {
         // Change the data as described in the change method
         fetchRes.rows.map((row) => {
           if (row.doc) {
-            const newDoc: any = changeMethod(row.doc);
-            if (newDoc) bulkUpdateDocs.push(newDoc);
+            const newDocData: any[] = changeMethod(row.doc);
+
+            // Add a document to the bulk update array for updating
+            if (newDocData.length)
+              if (newDocData[0]) bulkUpdateDocs.push(newDocData[0]);
+
+            // Log a message if one exists
+            if (newDocData.length === 2) console.log(newDocData[1]);
           }
         });
 
-        // Update the database
-        await this.db.bulk({
-          docs: bulkUpdateDocs,
-        });
-
-        // Avoid flooding the database
-        await sleep(10000);
+        // Update the database if any were found
+        if (bulkUpdateDocs.length)
+          await this.db.bulk({
+            docs: bulkUpdateDocs,
+          });
       }
       return true;
     }

--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -205,12 +205,11 @@ export class DatabaseHandler<T extends Document> {
   ): Promise<boolean> {
     const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
 
-    const bulkUpdateDocs: any[] = [];
-
     if (ids.length) {
       const chunks = chunkArray(ids, 100);
 
       for (let chunk of chunks) {
+        const bulkUpdateDocs: any[] = [];
         const fetchRes = await this.db.list({
           keys: chunk,
           include_docs: true,

--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -9,9 +9,11 @@ import {
   MangoQuery,
   MangoSelector,
   RequestError,
+  DocumentBulkResponse,
 } from "nano";
 
 import { mangoEqualSelector } from "./util.js";
+import { Noid, Timestamp } from "@crkn-rcdr/access-data";
 
 /**
  * The specification for a CouchDB document's `_attachments` object.
@@ -163,6 +165,26 @@ export class DatabaseHandler<T extends Document> {
       }
       throw error;
     }
+  }
+
+  async forceUpdateMany(
+    docs: {
+      _id: Noid;
+      updateInternalmeta: {
+        requestDate: Timestamp;
+      };
+    }[]
+  ): Promise<DocumentBulkResponse[]> {
+    /**
+     * https://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-docs
+     * For updating existing documents, you must provide the document ID, revision information (_rev), and new document values.
+     */
+
+    console.log("bulk: ", docs);
+
+    return await this.db.bulk({
+      docs,
+    });
   }
 
   /**

--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -193,7 +193,7 @@ export class DatabaseHandler<T extends Document> {
   }
 
   /**
-   * Updates all the objects in ids to add them to the hammer queue
+   * Updates all the objects in ids
    * @param ids Id strings for the objects to be updated
    * @returns the result of the bulk update
    *
@@ -221,9 +221,8 @@ export class DatabaseHandler<T extends Document> {
         // Change the data as described in the change method
         fetchRes.rows.map((row) => {
           if (row.doc) {
-            const doc: any = changeMethod(row.doc);
-            console.log(doc);
-            bulkUpdateDocs.push(doc);
+            const newDoc: any = changeMethod(row.doc);
+            if (newDoc) bulkUpdateDocs.push(newDoc);
           }
         });
 

--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -228,7 +228,8 @@ export class DatabaseHandler<T extends Document> {
         await this.db.bulk({
           docs: bulkUpdateDocs,
         });
-        sleep(10000);
+
+        await sleep(10000);
       }
       return true;
     }

--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -13,7 +13,6 @@ import {
 } from "nano";
 
 import { mangoEqualSelector } from "./util.js";
-import { Noid, Timestamp } from "@crkn-rcdr/access-data";
 
 /**
  * The specification for a CouchDB document's `_attachments` object.
@@ -177,27 +176,18 @@ export class DatabaseHandler<T extends Document> {
 
     const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
 
-    const bulkUpdateDocs: {
-      _rev: string;
-      _id: Noid;
-      updateInternalmeta: {
-        requestDate: Timestamp;
-      };
-    }[] = [];
+    const bulkUpdateDocs: any[] = [];
 
-    const fetchRes = await this.db.list({ keys: ids });
+    // TODO: figure out a way to handle many ids... maybe take advantage of pagination...
+    const fetchRes = await this.db.list({ keys: ids, include_docs: true });
 
     fetchRes.rows.map((row) => {
-      console.log("row", row);
-      //TODO: how to get this to only replace the feilds in here not the full doc?
-      if (row.id && row.value?.rev) {
-        bulkUpdateDocs.push({
-          _id: row.id,
-          _rev: row.value.rev,
-          updateInternalmeta: {
-            requestDate: date,
-          },
-        });
+      if (row.doc) {
+        let doc: any = { ...row.doc };
+        doc["updateInternalmeta"] = {
+          requestDate: date,
+        };
+        bulkUpdateDocs.push(doc);
       }
     });
 

--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -166,14 +166,17 @@ export class DatabaseHandler<T extends Document> {
     }
   }
 
+  /**
+   * Updates all the objects in ids to add them to the hammer queue
+   * @param ids Id strings for the objects to be updated
+   * @returns the result of the bulk update
+   *
+   * See: https://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-docs
+   * For updating existing documents, you must provide the document ID, revision information (_rev), and new document values.
+   */
   async forceUpdateMany(
     ids: any[] // todo: make string once object list item id is not optional
   ): Promise<DocumentBulkResponse[]> {
-    /**
-     * https://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-docs
-     * For updating existing documents, you must provide the document ID, revision information (_rev), and new document values.
-     */
-
     const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
 
     const bulkUpdateDocs: any[] = [];

--- a/packages/couch-utils/src/handlers/access.ts
+++ b/packages/couch-utils/src/handlers/access.ts
@@ -8,7 +8,7 @@ import {
   EditableCollection,
   EditableManifest,
   User,
-  ObjectList,
+  //ObjectList,
   Slug,
   NewCollection,
   NewManifest,
@@ -24,7 +24,7 @@ import {
 
 import { DatabaseHandler } from "../DatabaseHandler.js";
 
-import { xorWith, isEqual } from "lodash-es";
+//import { xorWith, isEqual } from "lodash-es";
 
 type SlugResolution =
   | { resolved: true; id: Noid; type: AccessObjectType }
@@ -158,19 +158,14 @@ export class AccessHandler extends DatabaseHandler<AccessObject> {
     data: EditableCollection;
   }): Promise<Collection> {
     const data = EditableCollection.parse(args.data);
-    let filteredMembers: ObjectList = [];
 
+    /*
+    let filteredMembers: ObjectList = [];
     if (data.members) {
       const currentMembers = Collection.parse(await this.get(args.id)).members;
 
-      const filteredMembers = xorWith(data.members, currentMembers, isEqual);
-
-      for (let members of filteredMembers) {
-        if (members.id !== undefined) {
-          await this.forceUpdate(members.id);
-        }
-      }
-    }
+      filteredMembers = xorWith(data.members, currentMembers, isEqual);
+    }*/
 
     await this.editObject({
       id: args.id,
@@ -178,11 +173,13 @@ export class AccessHandler extends DatabaseHandler<AccessObject> {
       data,
       type: "collection",
     });
-    for (let members of filteredMembers) {
+
+    /*for (let members of filteredMembers) {
       if (members.id !== undefined) {
         await this.forceUpdate(members.id);
       }
-    }
+    }*/
+
     const collection = await this.get(args.id);
     return Collection.parse(collection);
   }

--- a/packages/lapin-router/package.json
+++ b/packages/lapin-router/package.json
@@ -73,6 +73,7 @@
     "await-timeout": "1.0.1",
     "deep-object-diff": "^1.1.0",
     "node-fetch": "^2.6.1",
+    "node-worker-threads-pool": "^1.5.1",
     "queue-promise": "^2.2.1",
     "semaphore-async-await": "^1.5.1",
     "zod": "^3.7.1"

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -160,14 +160,23 @@ export const collectionRouter = createRouter()
 
           // Don't hold up the response. This will run in the background without causing issues for end users. They don't need to be alerted about any of this in real time. The updateInternalmeta is displayed in the editor.
           ctx.couch.access
-            .bulkChange(ids, (olddoc: any) => {
+            .bulkChange(ids, (oldDoc: any) => {
+              if (!oldDoc) return [null, "Error. Old document was null."];
+              if (!oldDoc["_id"])
+                return [null, "Error. Old document had no id."];
+              if (!oldDoc["_rev"])
+                return [null, "Error. Old document had no revision."];
+
               const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
-              return {
-                ...olddoc,
+
+              const newDoc = {
+                ...oldDoc,
                 updateInternalmeta: {
                   requestDate: date,
                 },
               };
+
+              return [newDoc];
             })
             .then((res: any) => {
               console.log("Forced Update Members: ", res);

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -158,25 +158,20 @@ export const collectionRouter = createRouter()
             .filter((member) => typeof member.id !== "undefined")
             .map((member) => member.id);
 
+          const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
           // Don't hold up the response. This will run in the background without causing issues for end users. They don't need to be alerted about any of this in real time. The updateInternalmeta is displayed in the editor.
           ctx.couch.access
-            .bulkChange(ids, (oldDoc: any) => {
-              if (!oldDoc) return [null, "Error. Old document was null."];
-              if (!oldDoc["_id"])
-                return [null, "Error. Old document had no id."];
-              if (!oldDoc["_rev"])
+            .bulkChange(ids, (doc: any) => {
+              if (!doc) return [null, "Error. Old document was null."];
+              if (!doc["_id"]) return [null, "Error. Old document had no id."];
+              if (!doc["_rev"])
                 return [null, "Error. Old document had no revision."];
 
-              const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
-
-              const newDoc = {
-                ...oldDoc,
-                updateInternalmeta: {
-                  requestDate: date,
-                },
+              doc.updateInternalmeta = {
+                requestDate: date,
               };
 
-              return [newDoc];
+              return [doc];
             })
             .then((res: any) => {
               console.log("Forced Update Members: ", res);

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -158,7 +158,7 @@ export const collectionRouter = createRouter()
             .filter((member) => typeof member.id !== "undefined")
             .map((member) => member.id);
 
-          // Don't hold up the response
+          // Don't hold up the response. This will run in the background without causing issues for end users. They don't need to be alerted about any of this in real time. The updateInternalmeta is displayed in the editor.
           ctx.couch.access
             .bulkChange(ids, (olddoc: any) => {
               const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
@@ -170,7 +170,7 @@ export const collectionRouter = createRouter()
               };
             })
             .then((res: any) => {
-              console.log("forceUpdateMany", res);
+              console.log("Forced Update Members: ", res);
             });
         }
 

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -157,7 +157,11 @@ export const collectionRouter = createRouter()
           const ids: any[] = res.members
             .filter((member) => typeof member.id !== "undefined")
             .map((member) => member.id);
-          await ctx.couch.access.forceUpdateMany(ids);
+
+          // Don't hold up the response
+          ctx.couch.access.forceUpdateMany(ids).then((res) => {
+            console.log("forceUpdateMany", res);
+          });
         }
 
         return res;

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -145,15 +145,20 @@ export const collectionRouter = createRouter()
       try {
         const res = await ctx.couch.access.editCollection(input);
 
-        //Todo: no filter needed after object list ids become required
-        const ids: any[] = res.members
-          .filter((member) => typeof member.id !== "undefined")
-          .map((member) => member.id);
-        console.log("ids", ids);
+        /**
+         * members of a multi-part collection that was edited (including label)
+         * members of an unordered collection that was edited (label doesn't matter, but public/private and slug does)
+         */
 
-        const res2 = await ctx.couch.access.forceUpdateMany(ids);
-
-        console.log("res2", res2);
+        if (
+          input.data.slug ||
+          (res.behavior === "multi-part" && input.data.label)
+        ) {
+          const ids: any[] = res.members
+            .filter((member) => typeof member.id !== "undefined")
+            .map((member) => member.id);
+          await ctx.couch.access.forceUpdateMany(ids);
+        }
 
         return res;
       } catch (e: any) {

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -10,7 +10,6 @@ import {
   Slug,
   ObjectListPage,
   TextRecord,
-  Timestamp,
 } from "@crkn-rcdr/access-data";
 import { createRouter, httpErrorToTRPC } from "../router.js";
 import { TRPCError } from "@trpc/server";
@@ -146,25 +145,13 @@ export const collectionRouter = createRouter()
       try {
         const res = await ctx.couch.access.editCollection(input);
 
-        const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
-        const docs: {
-          _id: Noid;
-          updateInternalmeta: {
-            requestDate: Timestamp;
-          };
-        }[] = [];
-        for (let member of res.members) {
-          if (member.id) {
-            docs.push({
-              _id: member.id,
-              updateInternalmeta: {
-                requestDate: date,
-              },
-            });
-          }
-        }
+        //Todo: no filter needed after object list ids become required
+        const ids: any[] = res.members
+          .filter((member) => typeof member.id !== "undefined")
+          .map((member) => member.id);
+        console.log("ids", ids);
 
-        const res2 = await ctx.couch.access.forceUpdateMany(docs);
+        const res2 = await ctx.couch.access.forceUpdateMany(ids);
 
         console.log("res2", res2);
 

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -159,9 +159,19 @@ export const collectionRouter = createRouter()
             .map((member) => member.id);
 
           // Don't hold up the response
-          ctx.couch.access.forceUpdateMany(ids).then((res) => {
-            console.log("forceUpdateMany", res);
-          });
+          ctx.couch.access
+            .bulkChange(ids, (olddoc: any) => {
+              const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
+              return {
+                ...olddoc,
+                updateInternalmeta: {
+                  requestDate: date,
+                },
+              };
+            })
+            .then((res: any) => {
+              console.log("forceUpdateMany", res);
+            });
         }
 
         return res;

--- a/packages/lapin-router/src/routes/manifest.ts
+++ b/packages/lapin-router/src/routes/manifest.ts
@@ -208,9 +208,19 @@ export const manifestRouter = createRouter()
             .filter((collection) => typeof collection.id !== "undefined")
             .map((collection) => collection.id);
           // Don't hold up the response
-          ctx.couch.access.forceUpdateMany(ids).then((res) => {
-            console.log("forceUpdateMany", res);
-          });
+          ctx.couch.access
+            .bulkChange(ids, (olddoc: any) => {
+              const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
+              return {
+                ...olddoc,
+                updateInternalmeta: {
+                  requestDate: date,
+                },
+              };
+            })
+            .then((res: any) => {
+              console.log("forceUpdateMany", res);
+            });
         }
 
         return res;

--- a/packages/lapin-router/src/routes/manifest.ts
+++ b/packages/lapin-router/src/routes/manifest.ts
@@ -207,7 +207,8 @@ export const manifestRouter = createRouter()
           const ids: any[] = membership
             .filter((collection) => typeof collection.id !== "undefined")
             .map((collection) => collection.id);
-          // Don't hold up the response
+
+          // Don't hold up the response. This will run in the background without causing issues for end users. They don't need to be alerted about any of this in real time. The updateInternalmeta is displayed in the editor.
           ctx.couch.access
             .bulkChange(ids, (olddoc: any) => {
               const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");

--- a/packages/lapin-router/src/routes/manifest.ts
+++ b/packages/lapin-router/src/routes/manifest.ts
@@ -210,17 +210,26 @@ export const manifestRouter = createRouter()
 
           // Don't hold up the response. This will run in the background without causing issues for end users. They don't need to be alerted about any of this in real time. The updateInternalmeta is displayed in the editor.
           ctx.couch.access
-            .bulkChange(ids, (olddoc: any) => {
+            .bulkChange(ids, (oldDoc: any) => {
+              if (!oldDoc) return [null, "Error. Old document was null."];
+              if (!oldDoc["_id"])
+                return [null, "Error. Old document had no id."];
+              if (!oldDoc["_rev"])
+                return [null, "Error. Old document had no revision."];
+
               const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
-              return {
-                ...olddoc,
+
+              const newDoc = {
+                ...oldDoc,
                 updateInternalmeta: {
                   requestDate: date,
                 },
               };
+
+              return [newDoc];
             })
             .then((res: any) => {
-              console.log("forceUpdateMany", res);
+              console.log("Forced Parent Collections:", res);
             });
         }
 

--- a/packages/lapin-router/src/routes/manifest.ts
+++ b/packages/lapin-router/src/routes/manifest.ts
@@ -200,7 +200,17 @@ export const manifestRouter = createRouter()
     input: EditInput.parse,
     async resolve({ input, ctx }) {
       try {
-        return await ctx.couch.access.editManifest(input);
+        const res = await ctx.couch.access.editManifest(input);
+
+        const membership = await ctx.couch.access.getMembership(input.id);
+        if (membership?.length) {
+          const ids: any[] = membership
+            .filter((collection) => typeof collection.id !== "undefined")
+            .map((collection) => collection.id);
+          await ctx.couch.access.forceUpdateMany(ids);
+        }
+
+        return res;
       } catch (e) {
         throw httpErrorToTRPC(e);
       }

--- a/packages/lapin-router/src/routes/manifest.ts
+++ b/packages/lapin-router/src/routes/manifest.ts
@@ -208,25 +208,20 @@ export const manifestRouter = createRouter()
             .filter((collection) => typeof collection.id !== "undefined")
             .map((collection) => collection.id);
 
+          const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
           // Don't hold up the response. This will run in the background without causing issues for end users. They don't need to be alerted about any of this in real time. The updateInternalmeta is displayed in the editor.
           ctx.couch.access
-            .bulkChange(ids, (oldDoc: any) => {
-              if (!oldDoc) return [null, "Error. Old document was null."];
-              if (!oldDoc["_id"])
-                return [null, "Error. Old document had no id."];
-              if (!oldDoc["_rev"])
+            .bulkChange(ids, (doc: any) => {
+              if (!doc) return [null, "Error. Old document was null."];
+              if (!doc["_id"]) return [null, "Error. Old document had no id."];
+              if (!doc["_rev"])
                 return [null, "Error. Old document had no revision."];
 
-              const date = new Date().toISOString().replace(/.\d+Z$/g, "Z");
-
-              const newDoc = {
-                ...oldDoc,
-                updateInternalmeta: {
-                  requestDate: date,
-                },
+              doc.updateInternalmeta = {
+                requestDate: date,
               };
 
-              return [newDoc];
+              return [doc];
             })
             .then((res: any) => {
               console.log("Forced Parent Collections:", res);

--- a/packages/lapin-router/src/routes/manifest.ts
+++ b/packages/lapin-router/src/routes/manifest.ts
@@ -207,7 +207,10 @@ export const manifestRouter = createRouter()
           const ids: any[] = membership
             .filter((collection) => typeof collection.id !== "undefined")
             .map((collection) => collection.id);
-          await ctx.couch.access.forceUpdateMany(ids);
+          // Don't hold up the response
+          ctx.couch.access.forceUpdateMany(ids).then((res) => {
+            console.log("forceUpdateMany", res);
+          });
         }
 
         return res;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,7 @@ importers:
       await-timeout: 1.0.1
       deep-object-diff: ^1.1.0
       node-fetch: ^2.6.1
+      node-worker-threads-pool: ^1.5.1
       npm-run-all: ^4.1.5
       queue-promise: ^2.2.1
       semaphore-async-await: ^1.5.1
@@ -107,6 +108,7 @@ importers:
       await-timeout: 1.0.1
       deep-object-diff: 1.1.0
       node-fetch: 2.6.1
+      node-worker-threads-pool: 1.5.1
       queue-promise: 2.2.1
       semaphore-async-await: 1.5.1
       zod: 3.7.1
@@ -2270,6 +2272,10 @@ packages:
   /node-fetch/2.6.1:
     resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
     engines: {node: 4.x || >=6.0.0}
+    dev: false
+
+  /node-worker-threads-pool/1.5.1:
+    resolution: {integrity: sha512-7TXAhpMm+jO4MfESxYLtMGSnJWv+itdNHMdaFmeZuPXxwFGU90mtEB42BciUULXOUAxYBfXILAuvrSG3rQZ7mw==}
     dev: false
 
   /nodemon/2.0.12:

--- a/services/admin/src/lib/components/access-objects/EditorActions.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorActions.svelte
@@ -398,7 +398,23 @@ The editor actions component holds functionality that is responsible for perform
       >
     {/if}
 
-    <button class="secondary" on:click={handlePublishStatusChange}>
+    <button
+      class="secondary"
+      on:click={handlePublishStatusChange}
+      disabled={(serverObject["type"] === "manifest" ||
+        serverObject["type"] === "pdf") &&
+        !serverObject["public"] &&
+        !serverObject["dmdType"]}
+      data-tooltip={(serverObject["type"] === "manifest" ||
+        serverObject["type"] === "pdf") &&
+      !serverObject["public"] &&
+      !serverObject["dmdType"]
+        ? `Publishing is disabled for ${serverObject["type"]}s with no metadata. Please use the "Load Metadata" tool to add metadata to your ${serverObject["type"]}.`
+        : serverObject["public"]
+        ? `Hide this ${serverObject["type"]} from the access platform.`
+        : `Make this ${serverObject["type"]} available on the access platform.`}
+      data-tooltip-flow="bottom"
+    >
       {serverObject["public"] ? "Unpublish" : "Publish"}
     </button>
 

--- a/services/admin/src/lib/components/access-objects/EditorActions.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorActions.svelte
@@ -401,14 +401,8 @@ The editor actions component holds functionality that is responsible for perform
     <button
       class="secondary"
       on:click={handlePublishStatusChange}
-      disabled={(serverObject["type"] === "manifest" ||
-        serverObject["type"] === "pdf") &&
-        !serverObject["public"] &&
-        !serverObject["dmdType"]}
-      data-tooltip={(serverObject["type"] === "manifest" ||
-        serverObject["type"] === "pdf") &&
-      !serverObject["public"] &&
-      !serverObject["dmdType"]
+      disabled={!serverObject["public"] && !serverObject["dmdType"]}
+      data-tooltip={!serverObject["public"] && !serverObject["dmdType"]
         ? `Publishing is disabled for ${serverObject["type"]}s with no metadata. Please use the "Load Metadata" tool to add metadata to your ${serverObject["type"]}.`
         : serverObject["public"]
         ? `Hide this ${serverObject["type"]} from the access platform.`


### PR DESCRIPTION
I tested yesterday with the news collection, renaming it to newspapers. As well with my own small collection. Everything forked as expected. I tested the generalisation with my small collection. I'm going to run it again to reset the news collection too.