### PR TITLE
Support for large queries on the importer and add member pages. Show collection member publish status in listing.

### DIFF
--- a/packages/couch-utils/src/DatabaseHandler.ts
+++ b/packages/couch-utils/src/DatabaseHandler.ts
@@ -106,24 +106,6 @@ type BulkGetResponse<T extends Document> = {
 };
 
 /**
- * A helper method that breaks apart large arrays.
- * See: https://github.com/haio/chunk-array/blob/master/index.js
- */
-function chunkArray(array: any[], n: number) {
-  if (!array || !n) return array;
-
-  var length = array.length;
-  var slicePoint = 0;
-  var ret = [];
-
-  while (slicePoint < length) {
-    ret.push(array.slice(slicePoint, slicePoint + n));
-    slicePoint += n;
-  }
-  return ret;
-}
-
-/**
  * Handler for interactions with a CouchDB database.
  *
  * Also handles translating `_id` and `_attachments` to non-underscored versions.
@@ -146,6 +128,24 @@ export class DatabaseHandler<T extends Document> {
     this.parser = parser;
     this.client = client;
     this.db = client.use(db);
+  }
+
+  /**
+   * A helper method that breaks apart large arrays.
+   * See: https://github.com/haio/chunk-array/blob/master/index.js
+   */
+  chunkArray(array: any[], n: number) {
+    if (!array || !n) return array;
+
+    let length = array.length;
+    let slicePoint = 0;
+    let ret = [];
+
+    while (slicePoint < length) {
+      ret.push(array.slice(slicePoint, slicePoint + n));
+      slicePoint += n;
+    }
+    return ret;
   }
 
   /**
@@ -218,10 +218,10 @@ export class DatabaseHandler<T extends Document> {
   ): Promise<boolean> {
     if (ids.length) {
       // Only grab and update 100 items, max, at a time
-      const chunks = chunkArray(ids, 100);
+      const chunks = this.chunkArray(ids, 100);
 
       // Loop through the max 100 item long lists
-      for (let chunk of chunks) {
+      for (const chunk of chunks) {
         const bulkUpdateDocs: any[] = [];
 
         //Grab the items in the list

--- a/packages/couch-utils/src/handlers/access.ts
+++ b/packages/couch-utils/src/handlers/access.ts
@@ -24,8 +24,6 @@ import {
 
 import { DatabaseHandler } from "../DatabaseHandler.js";
 
-//import { xorWith, isEqual } from "lodash-es";
-
 type SlugResolution =
   | { resolved: true; id: Noid; type: AccessObjectType }
   | { resolved: false; error: SlugResolutionError };
@@ -159,26 +157,12 @@ export class AccessHandler extends DatabaseHandler<AccessObject> {
   }): Promise<Collection> {
     const data = EditableCollection.parse(args.data);
 
-    /*
-    let filteredMembers: ObjectList = [];
-    if (data.members) {
-      const currentMembers = Collection.parse(await this.get(args.id)).members;
-
-      filteredMembers = xorWith(data.members, currentMembers, isEqual);
-    }*/
-
     await this.editObject({
       id: args.id,
       user: args.user,
       data,
       type: "collection",
     });
-
-    /*for (let members of filteredMembers) {
-      if (members.id !== undefined) {
-        await this.forceUpdate(members.id);
-      }
-    }*/
 
     const collection = await this.get(args.id);
     return Collection.parse(collection);
@@ -292,14 +276,6 @@ export class AccessHandler extends DatabaseHandler<AccessObject> {
       },
       ...data,
     });
-    // Is this required?
-    if (data.members) {
-      for (let members of data.members) {
-        if (members.id !== undefined) {
-          await this.forceUpdate(members.id);
-        }
-      }
-    }
     const collection = await this.get(args.id);
     return Collection.parse(collection);
   }

--- a/packages/lapin-router/src/routes/collection.ts
+++ b/packages/lapin-router/src/routes/collection.ts
@@ -230,7 +230,6 @@ export const collectionRouter = createRouter()
           }
           filteredMembers = xorWith(identifiedMembers, members, isEqual);
         }
-        console.log(filteredMembers);
         if (filteredMembers.length) {
           await ctx.couch.access.processList({
             id,

--- a/packages/lapin-router/src/routes/wipmeta.ts
+++ b/packages/lapin-router/src/routes/wipmeta.ts
@@ -11,7 +11,6 @@ export const StorePreservationInput = z.object({
 export const wipmetaRouter = createRouter().mutation("storePreservation", {
   input: StorePreservationInput.parse,
   async resolve({ input, ctx }) {
-    console.log("preservation input: ", input);
     const { id, index, task } = input;
     // Throws user-readable TRPC errors for specific issues
     await storePreservation(ctx, id, task, index);

--- a/services/admin/src/lib/components/access-objects/EditorActions.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorActions.svelte
@@ -304,7 +304,7 @@ The editor actions component holds functionality that is responsible for perform
 
   function setDeletionModalTextError() {
     deleteModalTitle = `${serverObject["slug"]} can't be deleted.`;
-    deleteModalMsg = `There was a problem when  background processes ran that is preventing ${serverObject["slug"]} from being deleted. Message: ${serverObject["updateInternalmeta"]?.["message"]}`;
+    deleteModalMsg = `There was a problem when background processes ran on ${serverObject["slug"]} that is preventing it from being deleted. Message: ${serverObject["updateInternalmeta"]?.["message"]}`;
     deleteModalActionText = `Ok`;
   }
 
@@ -324,6 +324,7 @@ The editor actions component holds functionality that is responsible for perform
         isDeleteModalWaiting = false;
         setDeletionModalTextEnabled();
       } else if (!serverObject.updateInternalmeta) {
+        console.log("two");
         isDeleteModalWaiting = false;
         setDeletionModalTextEnabled();
       } else {

--- a/services/admin/src/lib/components/access-objects/PrefixSlugSearchbox.svelte
+++ b/services/admin/src/lib/components/access-objects/PrefixSlugSearchbox.svelte
@@ -52,14 +52,25 @@ The resolver component allows the user to enter a slug, and then a request is se
    */
   async function handleSlugsChange() {
     loading = true;
+
+    // Split the slug textbox input by space or commas
     let slugs = input.split(/[,|\s]/);
+
+    // Strip any weird characters (to handle copy pasting from documents)
+    // And do not take empty lines
     slugs = slugs
       .map((slug) => slug.trim().replace(/[^\x00-\x7F]/g, ""))
       .filter((slug) => slug.length);
+
+    // Add the prefix if one is selected
     if (prefix?.prefix !== "none") {
       slugs = slugs.map((slug) => prefix?.prefix + slug);
     }
+
+    // Strip duplicates from the array
     slugs = [...new Set(slugs)];
+
+    // Send array to parent
     dispatch("slugs", slugs);
     loading = false;
   }

--- a/services/admin/src/lib/components/access-objects/PrefixSlugSearchbox.svelte
+++ b/services/admin/src/lib/components/access-objects/PrefixSlugSearchbox.svelte
@@ -28,23 +28,7 @@ The resolver component allows the user to enter a slug, and then a request is se
   import { getStores } from "$app/stores";
 
   import PrefixSelector from "$lib/components/access-objects/PrefixSelector.svelte";
-  import NotificationBar from "../shared/NotificationBar.svelte";
-
-  let depositor = {
-    prefix: "none",
-    label: "",
-  };
-
-  let input = "";
-  let error: string;
-
-  /**
-   * @type {boolean}
-  /**
-   * Whether to hide the display when the current slug is the
-   * same as the initial slug provided.
-   */
-  let hideInitial = false;
+  import Loading from "../shared/Loading.svelte";
 
   /**
    * @type {Session} The session store that contains the module for sending requests to lapin.
@@ -56,64 +40,54 @@ The resolver component allows the user to enter a slug, and then a request is se
    */
   const dispatch = createEventDispatcher();
 
+  let prefix = {
+    prefix: "none",
+    label: "",
+  };
+  let input = "";
+
+  let loading = false;
   /**
-   * Searches the backend for an object by the inputted slug. It also shows various error states to the user.
    * @returns void
    */
-
-  async function slugSelector() {
-    error = "";
+  async function handleSlugsChange() {
+    loading = true;
     let slugs = input.split(/[,|\s]/);
-    if (depositor?.prefix !== "none") {
-      slugs = slugs.map((slug) => depositor?.prefix + slug);
+    slugs = slugs
+      .map((slug) => slug.trim().replace(/[^\x00-\x7F]/g, ""))
+      .filter((slug) => slug.length);
+    if (prefix?.prefix !== "none") {
+      slugs = slugs.map((slug) => prefix?.prefix + slug);
     }
-
-    try {
-      const response = await $session.lapin.mutation("slug.resolveMany", slugs);
-      //console.log("response", response);
-
-      dispatch("found", response);
-    } catch (e) {
-      console.log(e);
-      error =
-        "There was a problem with your search. Please contact the platform team for assistance.";
-    }
-    hideInitial = true;
+    slugs = [...new Set(slugs)];
+    dispatch("slugs", slugs);
+    loading = false;
   }
 
-  function clear() {
-    input = "";
-    depositor = {
-      prefix: "none",
-      label: "",
-    };
+  $: {
+    input;
+    handleSlugsChange();
   }
 </script>
 
 <div>
-  <NotificationBar status="fail" message={error} />
-  {#if !hideInitial}
-    <PrefixSelector bind:depositor /><br /><br />
-
-    <div class="grid">
-      <textarea bind:value={input} />
-    </div>
-    <br />
-    <button class="primary lg" on:click={clear}>Clear</button>
-    <button class="primary lg" on:click={slugSelector}>Lookup</button> <br />
+  <PrefixSelector bind:depositor={prefix} /><br />
+  <textarea
+    rows="4"
+    placeholder="Enter a list of slugs seperated by commas or new lines."
+    bind:value={input}
+  />
+  <br />
+  {#if loading}
+    <span class="loader">
+      <Loading size="sm" backgroundType="gradient" /> Please wait, sanitizing list...
+    </span>
   {/if}
 </div>
 
 <style>
   textarea {
-    display: grid;
-    background-color: var(--primary-light);
     width: 100%;
     height: 100%;
-    grid-column: 1/2;
-  }
-  .grid {
-    display: grid;
-    grid-column: 1/1;
   }
 </style>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -527,6 +527,11 @@ Allows the user to modify the member list for a collection.
               </div>
               <div class="actions-wrap">
                 <div class="auto-align auto-align__column">
+                  {#if collectionMember.public}
+                    <div class="published">published</div>
+                  {:else}
+                    <div class="unpublished">unpublished</div>
+                  {/if}
                   <div
                     class="action icon"
                     data-tooltip="Remove from collection"

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -21,13 +21,12 @@ Allows the user to modify the member list for a collection.
   import CollectionMembersAddition from "./CollectionMembersAddition.svelte";
   import { page as pageStore } from "$app/stores";
   import { session } from "$app/stores";
-  import type { ObjectListPage } from "@crkn-rcdr/access-data";
+  import type { ObjectListPage, Timestamp } from "@crkn-rcdr/access-data";
   import DynamicDragAndDropList from "../shared/DynamicDragAndDropList.svelte";
   import DynamicDragAndDropListItem from "../shared/DynamicDragAndDropListItem.svelte";
   import { showConfirmation } from "$lib/utils/confirmation";
   import Loading from "../shared/Loading.svelte";
   import Paginator from "../shared/Paginator.svelte";
-  import CanvasLabelEditor from "../canvases/CanvasLabelEditor.svelte";
 
   export let collection: PagedCollection;
 
@@ -48,6 +47,7 @@ Allows the user to modify the member list for a collection.
     id?: string;
     label?: Record<string, string>;
     slug?: string;
+    public?: Timestamp;
   }[] = [];
 
   let positions: number[] = [];
@@ -490,7 +490,12 @@ Allows the user to modify the member list for a collection.
                   </a>
                 </div>
                 <div class="actions-wrap">
-                  <div class="auto-align auto-align__column">
+                  <div class="auto-align auto-align__column auto-align__a-end">
+                    {#if collectionMember.public}
+                      <div class="published">published</div>
+                    {:else}
+                      <div class="unpublished">unpublished</div>
+                    {/if}
                     <div
                       class="action icon"
                       data-tooltip="Remove from collection"
@@ -568,7 +573,8 @@ Allows the user to modify the member list for a collection.
     font-weight: 400;
     margin-bottom: 0.56rem;
     margin-left: 0.56rem;
-    min-width: 3.15rem;
+    min-width: 3.03rem;
+    padding-top: 0.45em;
   }
   .action.icon {
     display: none;
@@ -639,5 +645,14 @@ Allows the user to modify the member list for a collection.
   }*/
   .label {
     flex: 9;
+    padding-top: 0.45em;
+  }
+  .published {
+    color: var(--success);
+    margin-bottom: 0.5em;
+  }
+  .unpublished {
+    color: var(--secondary);
+    margin-bottom: 0.5em;
   }
 </style>

--- a/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
+++ b/services/admin/src/lib/components/collections/CollectionContentEditor.svelte
@@ -415,9 +415,7 @@ Allows the user to modify the member list for a collection.
       page = parseInt($pageStore.query.get("page"));
       handlePage({ detail: { page } });
     } else {
-      console.log("firstPage", firstPage);
-      members = firstPage.list;
-      //getMemberContext(firstPage.list);
+      members = firstPage?.list;
     }
   });
 

--- a/services/admin/src/lib/components/collections/CollectionMembersAddition.svelte
+++ b/services/admin/src/lib/components/collections/CollectionMembersAddition.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  import type { Depositor, Session } from "$lib/types";
+  import type { Session } from "$lib/types";
   import { getStores } from "$app/stores";
   import { createEventDispatcher } from "svelte";
   import type { PagedCollection } from "@crkn-rcdr/access-data/src/access/Collection";
   import TiArrowBack from "svelte-icons/ti/TiArrowBack.svelte";
 
-  import PrefixSelector from "$lib/components/access-objects/PrefixSelector.svelte";
   import NotificationBar from "../shared/NotificationBar.svelte";
+  import PrefixSlugSearchbox from "../access-objects/PrefixSlugSearchbox.svelte";
+  import LoadingButton from "../shared/LoadingButton.svelte";
 
   /**
    * @type {PagedCollection} The Collection where the members are added to.
@@ -21,29 +22,18 @@
   /**
    * @type {string} If a Collection is selected.
    */
-  let isMemberSelected = false;
   let addingMembers = false;
 
   /**
    * @type {boolean} If the add button should be displayed over the list of members.
    */
   export let showAddButton = true;
-  /**
-   * @type {string} An prefix to the Depositor.
-   */
-  let depositor: Depositor = {
-    prefix: "none",
-    label: "",
-  };
+
   /**
    * @type { string } The label for the by-slug toggle
    */
   const LOOKUP_MEMBER_BUTTON_TEXT = "Add a member";
 
-  /**
-   * @type { string } The selected lookup method
-   */
-  let memberLookup: string = LOOKUP_MEMBER_BUTTON_TEXT;
   /**
    * @type { boolean } If the lookup has completed run once yet.
    */
@@ -66,9 +56,9 @@
   }
 
   let id: string = destinationMember.id;
-  let input: string;
+  let slugArray: string[] = [];
   let error: string;
-  //  let documentSlug: {} = [];
+  let searching: boolean = false;
 
   // https://github.com/sindresorhus/type-fest/blob/main/source/promise-value.d.ts
   type PromiseValue<PromiseType> = PromiseType extends PromiseLike<infer Value>
@@ -77,12 +67,12 @@
   let resolutions: PromiseValue<ReturnType<typeof resolveMembers>>;
 
   async function resolveMembers() {
-    lookupDone = false;
-    error = "";
-    let slugArray = input.split(/[,|\s]/);
+    console.log(slugArray);
+    if (!slugArray.length) return;
 
-    if (depositor?.prefix !== "none")
-      slugArray = slugArray.map((slug) => `${depositor?.prefix}.${slug}`);
+    lookupDone = false;
+    searching = true;
+    error = "";
 
     if (id) {
       try {
@@ -102,6 +92,7 @@
         }
         selectedResults = selectedResults;
         lookupDone = true;
+        searching = false;
 
         // I'm returning here so that we can type `resolutions` properly (see above)
         return response;
@@ -133,6 +124,7 @@
           })
         );
         lookupDone = true;
+        searching = false;
 
         // I'm returning here so that we can type `resolutions` properly (see above)
         return response;
@@ -146,7 +138,7 @@
   function handleCancelPressed() {
     addingMembers = false;
     showAddButton = true;
-    clearText();
+    slugArray = [];
     dispatch("done");
   }
 
@@ -177,15 +169,8 @@
     addingMembers = false;
     showAddButton = true;
     selectedResults = [];
+    slugArray = [];
     resolutions = {};
-    clearText();
-  }
-  function clearText() {
-    input = "";
-    depositor = {
-      prefix: "none",
-      label: "",
-    };
   }
 </script>
 
@@ -220,20 +205,26 @@
         found.
       </p>
       <div>
-        <PrefixSelector bind:depositor />
+        <!--PrefixSelector bind:depositor />
         <textarea
           rows="4"
           placeholder="Enter a list of slugs seperated by commas or new lines."
           bind:value={input}
-        /><br />
-        <button
-          class="lg"
-          class:primary={!lookupDone}
-          class:secondary={lookupDone}
-          on:click={resolveMembers}>Search</button
+        /><br /-->
+        <PrefixSlugSearchbox
+          on:slugs={(event) => {
+            console.log("slugs:", event.detail);
+            slugArray = event.detail;
+          }}
+        />
+        <LoadingButton
+          buttonClass={lookupDone ? "secondary" : "primary"}
+          disabled={slugArray.length === 0}
+          showLoader={searching}
+          on:clicked={resolveMembers}
         >
-        <button class="secondary lg" on:click={clearText}>Clear Text</button>
-        <br />
+          <span slot="content">{searching ? "Searching..." : "Search"}</span>
+        </LoadingButton>
       </div>
       <br />
       <NotificationBar status="fail" message={error} />
@@ -268,9 +259,11 @@
                       bind:value={resolution.id}
                       checked={selectedResults.includes(resolution.id)}
                     />
-                    {resolution.id}
+                    <a href={`/object/edit/${resolution.id}`} target="_blank">
+                      {resolution.id}
+                    </a>
                   {:else}
-                    <span>No ID resolved to add</span>
+                    <span>Can't add to collection</span>
                   {/if}
                 </td>
               </tr>
@@ -280,8 +273,10 @@
           <button
             class="primary"
             disabled={!selectedResults.length}
-            on:click={handleAddPressed}>Add Selected Items</button
+            on:click={handleAddPressed}
           >
+            Add Selected Items
+          </button>
           <br />
           <br />
         </table>

--- a/services/admin/src/lib/components/collections/CollectionMembersAddition.svelte
+++ b/services/admin/src/lib/components/collections/CollectionMembersAddition.svelte
@@ -165,7 +165,6 @@
   async function handleAddPressed() {
     if (adding) return;
     adding = true;
-    console.log("adding", selectedResults);
     dispatch("done", {
       selectedMembers: selectedResults,
     });
@@ -219,7 +218,6 @@
         /><br /-->
         <PrefixSlugSearchbox
           on:slugs={(event) => {
-            console.log("slugs:", event.detail);
             slugArray = event.detail;
           }}
         />

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
@@ -196,7 +196,6 @@ This component allows the user to find packages in the dipstaging database.
         /-->
         <PrefixSlugSearchbox
           on:slugs={(event) => {
-            console.log("slugs:", event.detail);
             slugList = event.detail;
           }}
         />

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookup.svelte
@@ -24,6 +24,7 @@ This component allows the user to find packages in the dipstaging database.
   import NotificationBar from "../shared/NotificationBar.svelte";
   import Datepicker from "../shared/Datepicker.svelte";
   import { onMount } from "svelte";
+  import PrefixSlugSearchbox from "../access-objects/PrefixSlugSearchbox.svelte";
 
   /**
    * @type {ImportStatus[]}
@@ -35,18 +36,6 @@ This component allows the user to find packages in the dipstaging database.
    * @type {Session} The session store that contains the module for sending requests to lapin.
    */
   const { session } = getStores<Session>();
-
-  /**
-   * @type { Depositor } The access platform to look for the items in.
-   */
-  let depositor: Depositor | null = {
-    prefix: "none",
-    label: "No Prefix or Prefix Already Added",
-  };
-  /*{
-    prefix: "none",
-    label: "",
-  };*/
 
   /**
    * @type { string } The label for the by-slug toggle
@@ -74,12 +63,7 @@ This component allows the user to find packages in the dipstaging database.
   let endDateStr: string = "";
 
   /**
-   * @type { string } The value of the text input where users can enter slugs
-   */
-  let slugListString: string = "";
-
-  /**
-   * @type { string } The array of slugs derived from @var slugListString
+   * @type { string } The array of slugs
    */
   let slugList: string[] = [];
 
@@ -159,32 +143,22 @@ This component allows the user to find packages in the dipstaging database.
    */
   async function sendLookupRequestAIPIds() {
     if (loading) return;
+    if (!slugList.length) return;
     loading = true;
-    if (slugList.includes(",")) slugList = slugListString.split(",");
-    else slugList = slugListString.split("\n");
-    slugList = slugList.filter((slug) => slug.trim().length);
-    console.log("Searching", slugList);
-    if (slugList.length) {
-      if (depositor?.prefix !== "none")
-        slugList = slugList.map(
-          (slug) => `${depositor?.prefix}.${slug.trim()}`
-        );
-      else slugList = slugList.map((slug) => slug.trim());
 
-      try {
-        const response = await $session.lapin.query(
-          "dipstaging.listFromKeys",
-          slugList
-        );
-        if (response) results = response;
-      } catch (e) {
-        error = e?.message.includes(`"path:"`)
-          ? "Code 1. Please contact the platform team for assistance."
-          : "Code 2. Please contact the platform team for assistance.";
-      }
-
-      lookupDone = true;
+    try {
+      const response = await $session.lapin.query(
+        "dipstaging.listFromKeys",
+        slugList
+      );
+      if (response) results = response;
+    } catch (e) {
+      error = e?.message.includes(`"path:"`)
+        ? "Code 1. Please contact the platform team for assistance."
+        : "Code 2. Please contact the platform team for assistance.";
     }
+
+    lookupDone = true;
     loading = false;
   }
 
@@ -214,11 +188,17 @@ This component allows the user to find packages in the dipstaging database.
   <div class="user-input">
     {#if lookupView === BY_SLUG_LABEL}
       <div class="extra-spacing">
-        <PrefixSelector bind:depositor />
+        <!--PrefixSelector bind:depositor />
         <textarea
           rows="16"
           placeholder="Enter a list of slugs seperated by commas or new lines."
           bind:value={slugListString}
+        /-->
+        <PrefixSlugSearchbox
+          on:slugs={(event) => {
+            console.log("slugs:", event.detail);
+            slugList = event.detail;
+          }}
         />
         <br />
         <br />
@@ -259,7 +239,7 @@ This component allows the user to find packages in the dipstaging database.
         buttonClass={lookupDone ? "secondary" : "primary"}
         on:clicked={handleLookupPressedSlugList}
         showLoader={loading}
-        disabled={!depositor || slugListString.length === 0}
+        disabled={slugList.length === 0}
       >
         <span slot="content"> Look-up Packages </span>
       </LoadingButton>
@@ -285,9 +265,6 @@ This component allows the user to find packages in the dipstaging database.
     flex: 9;
   }
   .extra-spacing {
-    width: 100%;
-  }
-  textarea {
     width: 100%;
   }
   .lookup-button {

--- a/services/admin/src/lib/components/manifests/ManifestContentEditor.svelte
+++ b/services/admin/src/lib/components/manifests/ManifestContentEditor.svelte
@@ -175,10 +175,6 @@ Allows the user to modify the canvas list for a manifest.
 </script>
 
 {#if manifest}
-  <!--NotificationBar
-    message={typedChecks.manifest.getCanvasesValidationMsg(canvases)}
-    status="fail"
-  /-->
   <div class="auto-align auto-align__full content-wrapper">
     <div class="list-wrapper">
       <CanvasThumbnailList

--- a/services/admin/src/lib/utils/validation.ts
+++ b/services/admin/src/lib/utils/validation.ts
@@ -9,7 +9,6 @@ import {
   EditableManifest,
   Slug,
   TextRecord,
-  ObjectList,
   PagedAccessObject,
   Pdf,
 } from "@crkn-rcdr/access-data";
@@ -136,20 +135,6 @@ const manifest = {
       EditableManifest.parse({ label });
       return "";
     } catch (e) {
-      return e["issues"][0]["message"];
-    }
-  },
-  /**
-   * Validates the ObjectList passed in. Returns a message if the ObjectList is invalid.
-   * @param canvases
-   * @returns string
-   */
-  getCanvasesValidationMsg: function (canvases: ObjectList) {
-    try {
-      EditableManifest.parse({ canvases });
-      return "";
-    } catch (e) {
-      console.log(e?.message);
       return e["issues"][0]["message"];
     }
   },


### PR DESCRIPTION
As Beth was testing she ran into a few problems (https://github.com/crkn-rcdr/Access-Platform/issues/464)

The requests to couch are chunked (for now, we can look into the couch configs to increase the timeout later) to handle very large arrays of slugs. (See changes to files in couch-utils) A check for duplicates was also added to the request for adding members, since Beth noticed she had duplicate members added.

There are some more checks done in the slug search and the input was moved to a re-usable component to remove code duplication between the importer and member addition. See /components/access-objects/PrefixSlugSearchbox.svelte and the handleSlugsChange method for the checks done.

I quickly added the publish status of collection members as I was touching up the member search with the PrefixSlugSearchbox component. Because during the import flow, it's not obvious that you need to publish your manifest after adding it to your collection. Having the publish status there reminds people to do so and lets them save a lot of time looking through each item to see if it's published or not. 

