### PR TITLE
Adding dmdType check in couchdb updateObject design doc  (forceUpdate & editObject) + fixed a bug with the create new collection/manifest button

### DIFF
--- a/services/admin/src/lib/components/access-objects/EditorForm.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorForm.svelte
@@ -218,7 +218,7 @@ This component displays the non content properties for an access editorObject an
       </span><br /-->
     </div>
     <div class="cache-status">
-      {#if chacheStatus.found && chacheStatus.result}
+      {#if chacheStatus?.found && chacheStatus.result}
         {#if !("succeeded" in chacheStatus.result)}
           <table>
             <tbody>

--- a/services/admin/src/lib/components/collections/CollectionMembersAddition.svelte
+++ b/services/admin/src/lib/components/collections/CollectionMembersAddition.svelte
@@ -118,7 +118,7 @@
 
         resolutions = Object.fromEntries(
           response.map(([slug, r]): [string, any] => {
-            if (r.found) {
+            if (r?.found) {
               selectedResults.push(r.result.id);
               selectedResults = selectedResults;
               return [

--- a/services/couchdb/access/design/access/updates/publish.js
+++ b/services/couchdb/access/design/access/updates/publish.js
@@ -15,6 +15,10 @@ module.exports = function (doc, req) {
     return errorReturn(`Trying to publish an object that is already public`);
   }
 
+  if (!doc.dmdType) {
+    return errorReturn(`Descriptive Metadata missing`);
+  }
+
   const user = extractJSONFromBody(req);
 
   const now = timestamp();

--- a/services/couchdb/prelude.js
+++ b/services/couchdb/prelude.js
@@ -85,9 +85,10 @@ exports.updateObject = (doc, user) => {
     doc.staff = { by: user, date: now };
   }
 
-  if (doc.updateInternalmeta) delete doc.updateInternalmeta;
-  doc.updateInternalmeta = { requestDate: now };
-
+  if (doc.dmdType) {
+    if (doc.updateInternalmeta) delete doc.updateInternalmeta;
+    doc.updateInternalmeta = { requestDate: now };
+  }
   doc.updated = now;
 };
 


### PR DESCRIPTION
Two fixes, one for creating a new collection bug introduced when the updateInternalmeta status feature was added to the editor, the other checks for dmdType before updating updateInternalmeta to trigger hammer