### PR TITLE
When launching new smelt, clear past OCR data processing.

### DIFF
--- a/services/couchdb/dipstaging/design/access/updates/requestSmelt.js
+++ b/services/couchdb/dipstaging/design/access/updates/requestSmelt.js
@@ -24,6 +24,9 @@ module.exports = function (doc, req) {
     doc.slug = slug;
   }
 
+  // When launching new smelt, clear past OCR data processing.
+  delete doc.ocr;
+
   const now = timestamp();
   doc.smelt = { requestDate: now };
 


### PR DESCRIPTION
A trivial fix....

I believe that whenever a new Smelt is requested that any past OCR processing of that package should be cleared.  If the Smelt is successful, then the OCR processing will get re-run some time in the future.
