### PR TITLE
Importer enhancement & slug set to AIP id on page load

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     container_name: access-noid
     depends_on:
       - haproxy
-    image: docker.c7a.ca/noid:20210226
+    image: d948bd40f1fc
     volumes:
       - /noid/dbs
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     container_name: access-noid
     depends_on:
       - haproxy
-    image: d948bd40f1fc
+    image: docker.c7a.ca/noid:20210226
     volumes:
       - /noid/dbs
     networks:

--- a/services/admin/src/lib/components/access-objects/EditorForm.svelte
+++ b/services/admin/src/lib/components/access-objects/EditorForm.svelte
@@ -25,10 +25,10 @@ This component displays the non content properties for an access editorObject an
   } from "@crkn-rcdr/access-data";
   import { typedChecks } from "$lib/utils/validation";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
-  import Resolver from "$lib/components/access-objects/Resolver.svelte";
   import EditorInput from "$lib/components/access-objects/EditorInput.svelte";
   import { createEventDispatcher } from "svelte";
   import { showConfirmation } from "$lib/utils/confirmation";
+  import SlugSearch from "./SlugSearch.svelte";
   //import { editorObjectStore } from "$lib/stores/accessObjectEditorStore";
 
   /**
@@ -60,6 +60,8 @@ This component displays the non content properties for an access editorObject an
    * @type {<EventKey extends string>(type: EventKey, detail?: any)} Triggers events that parent components can hook into.
    */
   const dispatch = createEventDispatcher();
+
+  let isSlugValid = true;
 
   function handleSavePressed(event: any) {
     dispatch("save", event.detail);
@@ -109,15 +111,26 @@ This component displays the non content properties for an access editorObject an
           keys={["slug"]}
           bind:value={editorObject["slug"]}
           on:save={handleSavePressed}
-          saveDisabled={!editorObject["slug"] ||
-            editorObject["slug"].length === 0}
+          saveDisabled={!isSlugValid}
         >
           <div>
-            <Resolver bind:slug={editorObject["slug"]} />
+            <SlugSearch
+              searchOnLoad={false}
+              bind:slug={editorObject["slug"]}
+              on:slugValidity={(e) => {
+                isSlugValid = e.detail;
+              }}
+            />
           </div>
         </EditorInput>
       {:else}
-        <Resolver bind:slug={editorObject["slug"]} />
+        <SlugSearch
+          searchOnLoad={false}
+          bind:slug={editorObject["slug"]}
+          on:slugValidity={(e) => {
+            isSlugValid = e.detail;
+          }}
+        />
       {/if}
 
       <br /><br />

--- a/services/admin/src/lib/components/access-objects/Resolver.svelte
+++ b/services/admin/src/lib/components/access-objects/Resolver.svelte
@@ -94,7 +94,7 @@ The resolver component allows the user to enter a slug, and then a request is se
    * @returns void
    */
   async function resolve() {
-    if (slug !== previous && slug !== intitalSlug) {
+    if (runInitial || (slug !== previous && slug !== intitalSlug)) {
       if (timer) clearTimeout(timer);
       timer = setTimeout(async () => {
         status = "LOADING";

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -4,6 +4,7 @@
   import { getStores } from "$app/stores";
   import NotificationBar from "../shared/NotificationBar.svelte";
   import IoMdRefresh from "svelte-icons/io/IoMdRefresh.svelte";
+  import Loading from "../shared/Loading.svelte";
 
   export let searchOnLoad: boolean = true;
   export let slug;
@@ -35,6 +36,7 @@
   let found = false;
   let valid = true;
   let initital = "";
+  let loading = false;
 
   function search() {
     if (!slug?.length) return;
@@ -43,6 +45,7 @@
       valid = true;
       return;
     }
+    loading = true;
 
     valid = regex.test(slug);
 
@@ -56,13 +59,19 @@
         foundErrorMessage = `<a href ="/object/edit/${noid}" target="_blank">⚠️ Slug in use.</a>`;
       }
       dispatch("slugValidity", !found && valid);
+      loading = false;
     }, 50);
   }
 
   onMount(() => {
     initital = slug;
-    if (searchOnLoad) search();
+    //if (searchOnLoad) search();
   });
+
+  $: {
+    slug;
+    if (initital.length) search();
+  }
 </script>
 
 {#if !valid}
@@ -72,7 +81,11 @@
   <NotificationBar status="fail" message={foundErrorMessage} />
 {/if}
 <div class="input-wrap auto-align auto-align__a-center">
-  {#if found}
+  {#if loading}
+    <span class="loader">
+      <Loading size="sm" backgroundType="gradient" />
+    </span>
+  {:else if found}
     <span
       on:click={search}
       class="icon"
@@ -82,7 +95,7 @@
       <IoMdRefresh />
     </span>
   {/if}
-  <input placeholder="Type in a slug..." bind:value={slug} on:keyup={search} />
+  <input placeholder="Type in a slug..." bind:value={slug} />
 </div>
 
 <style>
@@ -96,5 +109,8 @@
     margin-right: 1rem;
     cursor: pointer;
     color: var(--secondary);
+  }
+  .loader {
+    margin-right: 1rem;
   }
 </style>

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -69,12 +69,12 @@
 <style>
   .input-wrap {
     width: 100%;
-    margin-top: 1rem;
   }
   input {
     flex: 9;
   }
   button {
     margin-left: 1rem;
+    margin-top: 1rem;
   }
 </style>

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -62,7 +62,7 @@
 <div class="input-wrap auto-align auto-align__a-center">
   <input placeholder="Type in a slug..." bind:value={slug} on:input={search} />
   {#if found}
-    <button class="secondary" on:click={search}>Try Again</button>
+    <button class="secondary" on:click={search}>Look-up Again</button>
   {/if}
 </div>
 

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -5,12 +5,12 @@
   import NotificationBar from "../shared/NotificationBar.svelte";
   import IoMdRefresh from "svelte-icons/io/IoMdRefresh.svelte";
   import Loading from "../shared/Loading.svelte";
-  import { initial } from "lodash-es";
 
   export let searchOnLoad: boolean = true;
   export let slug;
   export let noid = "";
   export let found = false;
+  export let tooltip = "";
 
   let invalidErrorMessage =
     "Slugs can only contain letters, numbers, and the following symbols: _ - .";
@@ -48,7 +48,6 @@
     found = response.found;
     if (response.found) {
       noid = response.result.id;
-      foundErrorMessage = `<a href ="/object/edit/${noid}" target="_blank">⚠️ Slug in use.</a>`;
     }
     dispatch("slugValidity", !found && valid);
     loading = false;
@@ -83,14 +82,27 @@
     if (searchOnLoad || hasSearched) search();
     hasSearched = true;
   }
+
+  $: {
+    if (noid)
+      foundErrorMessage = `<a href ="/object/edit/${noid}" target="_blank">⚠️ Slug in use.</a>`;
+  }
 </script>
 
 {#if !valid}
   <NotificationBar status="fail" message={invalidErrorMessage} />
 {/if}
+
 {#if found}
-  <NotificationBar status="fail" message={foundErrorMessage} />
+  {#if tooltip.length}
+    <div data-tooltip={tooltip}>
+      <NotificationBar status="fail" message={foundErrorMessage} />
+    </div>
+  {:else}
+    <NotificationBar status="fail" message={foundErrorMessage} />
+  {/if}
 {/if}
+
 <div class="input-wrap auto-align auto-align__a-center">
   {#if loading}
     <span class="loader">

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -5,10 +5,13 @@
   import NotificationBar from "../shared/NotificationBar.svelte";
   import IoMdRefresh from "svelte-icons/io/IoMdRefresh.svelte";
   import Loading from "../shared/Loading.svelte";
+  import { initial } from "lodash-es";
 
   export let searchOnLoad: boolean = true;
   export let slug;
   export let noid = "";
+  export let found = false;
+
   let invalidErrorMessage =
     "Slugs can only contain letters, numbers, and the following symbols: _ - .";
   let foundErrorMessage = "⚠️ Slug in use";
@@ -33,10 +36,10 @@
    */
   const dispatch = createEventDispatcher();
 
-  let found = false;
   let valid = true;
   let initital = "";
   let loading = false;
+  let hasSearched = false;
 
   function search() {
     if (!slug?.length) return;
@@ -45,6 +48,7 @@
       valid = true;
       return;
     }
+    if (!initital.length) initital = slug;
     loading = true;
 
     valid = regex.test(slug);
@@ -65,12 +69,12 @@
 
   onMount(() => {
     initital = slug;
-    //if (searchOnLoad) search();
   });
 
   $: {
     slug;
-    if (initital.length) search();
+    if (searchOnLoad || hasSearched) search();
+    hasSearched = true;
   }
 </script>
 

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -8,6 +8,7 @@
   export let invalidErrorMessage =
     "Slugs can only contain letters, numbers, and the following symbols: _ - .";
   export let foundErrorMessage = "⚠️ Slug in use";
+  export let noid;
 
   /**
    * @type {NodeJS.Timeout | null} Used to debounce the searching of slugs.
@@ -42,6 +43,7 @@
     timer = setTimeout(async () => {
       const response = await $session.lapin.query("slug.resolve", slug);
       found = response.found;
+      if (response.found) noid = response.result.id;
       dispatch("slugValidity", !found && valid);
     }, 50);
   }
@@ -52,16 +54,27 @@
 </script>
 
 {#if !valid}
-  woo
   <NotificationBar status="fail" message={invalidErrorMessage} />
 {/if}
 {#if found}
   <NotificationBar status="fail" message={foundErrorMessage} />
 {/if}
-<input placeholder="Type in a slug..." bind:value={slug} on:input={search} />
+<div class="input-wrap auto-align auto-align__a-center">
+  <input placeholder="Type in a slug..." bind:value={slug} on:input={search} />
+  {#if found}
+    <button class="secondary" on:click={search}>Try Again</button>
+  {/if}
+</div>
 
 <style>
-  input {
+  .input-wrap {
     width: 100%;
+    margin-top: 1rem;
+  }
+  input {
+    flex: 9;
+  }
+  button {
+    margin-left: 1rem;
   }
 </style>

--- a/services/admin/src/lib/components/access-objects/SlugSearch.svelte
+++ b/services/admin/src/lib/components/access-objects/SlugSearch.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { createEventDispatcher, onMount } from "svelte";
+  import type { Session } from "$lib/types";
+  import { getStores } from "$app/stores";
+  import NotificationBar from "../shared/NotificationBar.svelte";
+
+  export let slug;
+  export let invalidErrorMessage =
+    "Slugs can only contain letters, numbers, and the following symbols: _ - .";
+  export let foundErrorMessage = "⚠️ Slug in use";
+
+  /**
+   * @type {NodeJS.Timeout | null} Used to debounce the searching of slugs.
+   */
+  let timer: NodeJS.Timeout | null = null;
+
+  /**
+   * @type {RegExp} A regular expression that will validate strings as slugs.
+   */
+  const regex = /^[\p{L}\p{Nl}\p{Nd}\-_\.]+$/u;
+
+  /**
+   * @type {Session} The session store that contains the module for sending requests to lapin.
+   */
+  const { session } = getStores<Session>();
+
+  /**
+   * @type {<EventKey extends string>(type: EventKey, detail?: any)} Triggers events that parent components can hook into.
+   */
+  const dispatch = createEventDispatcher();
+
+  let found = true;
+  let valid = true;
+
+  function search() {
+    if (!slug?.length) return;
+
+    valid = regex.test(slug);
+
+    if (timer) clearTimeout(timer);
+
+    timer = setTimeout(async () => {
+      const response = await $session.lapin.query("slug.resolve", slug);
+      found = response.found;
+      dispatch("slugValidity", !found && valid);
+    }, 50);
+  }
+
+  onMount(() => {
+    search();
+  });
+</script>
+
+{#if !valid}
+  woo
+  <NotificationBar status="fail" message={invalidErrorMessage} />
+{/if}
+{#if found}
+  <NotificationBar status="fail" message={foundErrorMessage} />
+{/if}
+<input placeholder="Type in a slug..." bind:value={slug} on:input={search} />
+
+<style>
+  input {
+    width: 100%;
+  }
+</style>

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -329,6 +329,8 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                 </p>
                 <SlugSearch
                   bind:slug={slugMap[item["id"]]}
+                  searchOnLoad={false}
+                  found={slugUnavailableMap[slugMap[item["id"]]]}
                   noid={slugMap[item["id"]] in noidMap
                     ? noidMap[slugMap[item["id"]]]
                     : null}

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -324,59 +324,10 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   >Track its status in the 'Import Queue' tab.</a
                 >
               {:else}
-                <!--{#if slugUnavailableMap[slugMap[item["id"]]] && slugMap[item["id"]] === item["slug"]}
-                  <NotificationBar
-                    status="fail"
-                    message={isSlugSearch
-                      ? `The existing manifest must be  before the package can be re-imported into a new manifest.`
-                      : `This package is already imported as a  manifest.`}
-                  />
-
-                  <p>
-                    <br />
-                    <a
-                      href={`/object/edit/${noidMap[slugMap[item["id"]]]}`}
-                      target="_blank"
-                    >
-                      To replace the existing import of this package, please
-                      click here open it in the editor. Then, unpublish the
-                      manifest if it is published. Then, press delete to delete
-                      the manifest.
-                    </a> When you are done, click the button below to enable importing
-                    for your package.
-                  </p>
-
-                  <br />
-                  <button
-                    class="secondary"
-                    on:click={() => {
-                      slugUnavailableMap[slugMap[item["id"]]] = false;
-                      slugUnavailableMap = slugUnavailableMap;
-                    }}
-                  >
-                    OK, I have deleted the existing manifest.
-                  </button>
-                {:else}
-                  <span
-                    >Please enter the slug you would like to use for the
-                    manifest:
-                  </span-->
-                <!--Resolver
-                    isFound={slugUnavailableMap[slugMap[item["id"]]]}
-                    alwaysShowIfFound={true}
-                    runInitial={true}
-                    on:available={(e) => setSlugAvailability(e, item)}
-                    bind:slug={slugMap[item["id"]]}
-                  />
-
-                {/if} -->
                 <p class="slug-label">
-                  Please enter the slug you would like to use for the manifest:
+                  Please enter the slug for the manifest that will be created:
                 </p>
                 <SlugSearch
-                  foundErrorMessage={` <a href ="/object/edit/${
-                    noidMap[slugMap[item["id"]]]
-                  }" target="_blank">⚠️ Slug in use.</a>`}
                   bind:slug={slugMap[item["id"]]}
                   noid={slugMap[item["id"]] in noidMap
                     ? noidMap[slugMap[item["id"]]]

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -19,6 +19,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
   import type { Session } from "$lib/types";
   import type { ImportStatus, LegacyPackage } from "@crkn-rcdr/access-data";
   import Resolver from "$lib/components/access-objects/Resolver.svelte";
+  import SlugSearch from "$lib/components/access-objects/SlugSearch.svelte";
   import Loading from "$lib/components/shared/Loading.svelte";
   import NotificationBar from "$lib/components/shared/NotificationBar.svelte";
   import ExpansionTile from "$lib/components/shared/ExpansionTile.svelte";
@@ -138,7 +139,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
    * @returns void
    */
   function setSlugAvailability(event, item: ImportStatus | LegacyPackage) {
-    slugUnavailableMap[slugMap[item["id"]]] = !event.detail.status;
+    slugUnavailableMap[slugMap[item["id"]]] = !event.detail;
     slugUnavailableMap = slugUnavailableMap;
     if (isItemSelectable(item)) selectedMap[item["id"]] = true;
     else selectedMap[item["id"]] = false;
@@ -240,6 +241,15 @@ This component shows the results of a dipstaging find-package(s) request or a vi
       loading = false;
     });
   }
+
+  /*$: {
+    loading = true;
+    slugUnavailableMap;
+    getSlugAvailability().then(() => {
+      setSelectedModel();
+      loading = false;
+    });
+  }*/
 </script>
 
 <NotificationBar message={error} status="fail" />
@@ -316,11 +326,11 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   >Track its status in the 'Import Queue' tab.</a
                 >
               {:else}
-                {#if slugUnavailableMap[slugMap[item["id"]]] && slugMap[item["id"]] === item["slug"]}
+                <!--{#if slugUnavailableMap[slugMap[item["id"]]] && slugMap[item["id"]] === item["slug"]}
                   <NotificationBar
                     status="fail"
                     message={isSlugSearch
-                      ? `The existing manifest must be deleted before the package can be re-imported into a new manifest.`
+                      ? `The existing manifest must be  before the package can be re-imported into a new manifest.`
                       : `This package is already imported as a  manifest.`}
                   />
 
@@ -343,6 +353,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                     class="secondary"
                     on:click={() => {
                       slugUnavailableMap[slugMap[item["id"]]] = false;
+                      slugUnavailableMap = slugUnavailableMap;
                     }}
                   >
                     OK, I have deleted the existing manifest.
@@ -351,18 +362,26 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   <span
                     >Please enter the slug you would like to use for the
                     manifest:
-                  </span>
-                  <Resolver
+                  </span-->
+                <!--Resolver
                     noid={slugMap[item["id"]] in noidMap
                       ? noidMap[slugMap[item["id"]]]
                       : null}
                     isFound={slugUnavailableMap[slugMap[item["id"]]]}
                     alwaysShowIfFound={true}
-                    runInitial={false}
+                    runInitial={true}
                     on:available={(e) => setSlugAvailability(e, item)}
                     bind:slug={slugMap[item["id"]]}
                   />
-                {/if}
+
+                {/if} -->
+                <SlugSearch
+                  foundErrorMessage={"⚠️ Slug in use. Please enter a new slug here, edit the slug of the existing manifest, or delete the existing manifest to continue."}
+                  slug={slugMap[item["id"]]}
+                  on:slugValidity={(e) => {
+                    setSlugAvailability(e, item);
+                  }}
+                />
 
                 <br /><br />
 

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -374,9 +374,9 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   Please enter the slug you would like to use for the manifest:
                 </p>
                 <SlugSearch
-                  foundErrorMessage={`⚠️ Slug in use. Please enter a new slug here, <a href ="/object/edit/${
+                  foundErrorMessage={` <a href ="/object/edit/${
                     noidMap[slugMap[item["id"]]]
-                  }" target="_blank">edit the slug of the existing manifest, or delete the existing manifest to continue.</a>`}
+                  }" target="_blank">⚠️ Slug in use.</a>`}
                   bind:slug={slugMap[item["id"]]}
                   noid={slugMap[item["id"]] in noidMap
                     ? noidMap[slugMap[item["id"]]]
@@ -385,9 +385,15 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                     setSlugAvailability(e, item);
                   }}
                 />
-
-                <br /><br />
-
+                <div class="slug-error-instructions">
+                  The slug entered is currently in use. To resolve this issue,
+                  you can either:
+                  <ol type="1">
+                    <li>Enter a new slug above</li>
+                    <li>Edit the slug of the existing manifest</li>
+                    <li>Delete the existing manifest</li>
+                  </ol>
+                </div>
                 <div class="import-history-wrap">
                   <ExpansionTile>
                     <span slot="top">Last Import Status</span>
@@ -446,5 +452,9 @@ This component shows the results of a dipstaging find-package(s) request or a vi
   }
   .slug-label {
     margin-bottom: 1rem;
+  }
+  .slug-error-instructions {
+    margin-top: 1rem;
+    color: var(--secondary);
   }
 </style>

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -370,11 +370,14 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                   />
 
                 {/if} -->
+                <p class="slug-label">
+                  Please enter the slug you would like to use for the manifest:
+                </p>
                 <SlugSearch
                   foundErrorMessage={`⚠️ Slug in use. Please enter a new slug here, <a href ="/object/edit/${
                     noidMap[slugMap[item["id"]]]
                   }" target="_blank">edit the slug of the existing manifest, or delete the existing manifest to continue.</a>`}
-                  slug={slugMap[item["id"]]}
+                  bind:slug={slugMap[item["id"]]}
                   noid={slugMap[item["id"]] in noidMap
                     ? noidMap[slugMap[item["id"]]]
                     : null}
@@ -440,5 +443,8 @@ This component shows the results of a dipstaging find-package(s) request or a vi
     border-radius: var(--border-radius);
     border: 1px solid var(--border-color);
     padding: 1rem;
+  }
+  .slug-label {
+    margin-bottom: 1rem;
   }
 </style>

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -329,6 +329,14 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                 </p>
                 <SlugSearch
                   bind:slug={slugMap[item["id"]]}
+                  tooltip={`
+The slug entered is currently in use. To resolve this issue, you can either:
+  1. Enter a new slug below 
+  2. Edit the slug of the 
+       existing manifest
+  3. Delete the existing 
+       manifest
+                  `}
                   searchOnLoad={false}
                   found={slugUnavailableMap[slugMap[item["id"]]]}
                   noid={slugMap[item["id"]] in noidMap
@@ -338,15 +346,7 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                     setSlugAvailability(e, item);
                   }}
                 />
-                <div class="slug-error-instructions">
-                  The slug entered is currently in use. To resolve this issue,
-                  you can either:
-                  <ol type="1">
-                    <li>Enter a new slug above</li>
-                    <li>Edit the slug of the existing manifest</li>
-                    <li>Delete the existing manifest</li>
-                  </ol>
-                </div>
+
                 <div class="import-history-wrap">
                   <ExpansionTile>
                     <span slot="top">Last Import Status</span>

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -346,7 +346,8 @@ The slug entered is currently in use. To resolve this issue, you can either:
                     setSlugAvailability(e, item);
                   }}
                 />
-
+                <br />
+                <br />
                 <div class="import-history-wrap">
                   <ExpansionTile>
                     <span slot="top">Last Import Status</span>

--- a/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
+++ b/services/admin/src/lib/components/dipstaging/DipstagingLookupTable.svelte
@@ -157,10 +157,8 @@ This component shows the results of a dipstaging find-package(s) request or a vi
     for (const item of results) {
       let itemCopy = structuredClone(item);
       items.push(itemCopy);
-      if (!itemCopy["slug"] && !isSlugSearch) {
-        itemCopy["slug"] = itemCopy["id"];
-        slugMap[itemCopy["id"]] = itemCopy["id"];
-      } else slugMap[itemCopy["id"]] = itemCopy["slug"];
+      itemCopy["slug"] = itemCopy["id"]; // Ignore old slugs
+      slugMap[itemCopy["id"]] = itemCopy["id"];
     }
     items = items;
   }
@@ -364,9 +362,6 @@ This component shows the results of a dipstaging find-package(s) request or a vi
                     manifest:
                   </span-->
                 <!--Resolver
-                    noid={slugMap[item["id"]] in noidMap
-                      ? noidMap[slugMap[item["id"]]]
-                      : null}
                     isFound={slugUnavailableMap[slugMap[item["id"]]]}
                     alwaysShowIfFound={true}
                     runInitial={true}
@@ -376,8 +371,13 @@ This component shows the results of a dipstaging find-package(s) request or a vi
 
                 {/if} -->
                 <SlugSearch
-                  foundErrorMessage={"⚠️ Slug in use. Please enter a new slug here, edit the slug of the existing manifest, or delete the existing manifest to continue."}
+                  foundErrorMessage={`⚠️ Slug in use. Please enter a new slug here, <a href ="/object/edit/${
+                    noidMap[slugMap[item["id"]]]
+                  }" target="_blank">edit the slug of the existing manifest, or delete the existing manifest to continue.</a>`}
                   slug={slugMap[item["id"]]}
+                  noid={slugMap[item["id"]] in noidMap
+                    ? noidMap[slugMap[item["id"]]]
+                    : null}
                   on:slugValidity={(e) => {
                     setSlugAvailability(e, item);
                   }}

--- a/services/admin/src/lib/components/shared/DynamicDragAndDropList.svelte
+++ b/services/admin/src/lib/components/shared/DynamicDragAndDropList.svelte
@@ -159,9 +159,7 @@ A container that enables the dragging and dropping of it's children elements.
     const config = { attributes: false, childList: true, subtree: false };
     // Create an observer instance linked to the callback function
     const observer = new MutationObserver(function (mutationsList, observer) {
-      console.log("updating dragger");
       enableDraggingOnChildren();
-      console.log(mutationsList, observer);
     });
     // Start observing the target node for configured mutations
     observer.observe(container, config);


### PR DESCRIPTION
Please see the following screenshots, and let me know if anything should be changed!

Importer, refresh button allows the same slug to be searched again.
![importer](https://user-images.githubusercontent.com/10541019/156381383-c7f69b7b-2cb5-4954-80b7-6e019dc899f8.jpg)

Editor, refresh button allows the same slug to be searched again.
![editor](https://user-images.githubusercontent.com/10541019/156381400-d7502f98-f45d-47d2-a1ac-96bdaf9ffdd5.jpg)

There will be a loading status on search (helpful for slow connections)
![loading](https://user-images.githubusercontent.com/10541019/156381410-c0bdc336-2ff1-4798-86d1-c7f633af99ec.jpg)

I've tested the import process and slug editing process.

