### PR TITLE
View for quickly looking up the slug

### DIFF
--- a/services/couchdb/access/design/access/views/noid2slug.js
+++ b/services/couchdb/access/design/access/views/noid2slug.js
@@ -1,0 +1,5 @@
+module.exports = {
+  map: function (doc) {
+    emit(doc._id, doc.slug);
+  },
+};


### PR DESCRIPTION
I have many tools which result in noids, but I want to give lists of slugs to staff.  I had been using the _find interface, but that is extremely slow when looking up a large number of noids.

```
    "selector" => {
        "_id" => {
            '$in' => \@needocr
        }
    },
```

This creates a lookup which starts at the smallest value of $in and then looks at every database entry until it gets to the largest value in $in.

