### PR TITLE
Supporting slug being optional in `dipstaging` records.

### DIFF
--- a/services/couchdb/dipstaging/design/access/updates/requestSmelt.js
+++ b/services/couchdb/dipstaging/design/access/updates/requestSmelt.js
@@ -21,7 +21,11 @@ module.exports = function (doc, req) {
   updateGenericObject(doc, user);
 
   if (typeof slug === "string") {
-    doc.slug = slug;
+    if (slug === "") {
+      delete doc.slug;
+    } else {
+      doc.slug = slug;
+    }
   }
 
   // When launching new smelt, clear past OCR data processing.


### PR DESCRIPTION
If 

* slug='', then delete the (optional) existing slug
* slug=$slug means set the slug
* slug='' means delete the slug, no slug parameter means no change.

https://github.com/crkn-rcdr/Access-Platform/issues/585#issuecomment-1525628156